### PR TITLE
Add support for specifying what rules to run using the CLI

### DIFF
--- a/default-recommendations.rkt
+++ b/default-recommendations.rkt
@@ -5,23 +5,28 @@
 
 (provide
  (contract-out
-  [default-recommendations (listof refactoring-rule?)]))
+  [default-recommendations refactoring-suite?]))
 
 
-(require resyntax/default-recommendations/for-loop-shortcuts
+(require rebellion/private/static-name
+         resyntax/default-recommendations/for-loop-shortcuts
          resyntax/default-recommendations/legacy-contract-migrations
          resyntax/default-recommendations/legacy-struct-migrations
          resyntax/default-recommendations/let-binding-suggestions
          resyntax/default-recommendations/miscellaneous-suggestions
-         resyntax/refactoring-rule)
+         resyntax/refactoring-rule
+         resyntax/refactoring-suite)
 
 
 ;@----------------------------------------------------------------------------------------------------
 
 
 (define default-recommendations
-  (append for-loop-shortcuts
-          legacy-contract-migrations
-          legacy-struct-migrations
-          let-binding-suggestions
-          miscellaneous-suggestions))
+  (refactoring-suite
+   #:name (name default-recommendations)
+   #:rules
+   (append (refactoring-suite-rules for-loop-shortcuts)
+           (refactoring-suite-rules legacy-contract-migrations)
+           (refactoring-suite-rules legacy-struct-migrations)
+           (refactoring-suite-rules let-binding-suggestions)
+           (refactoring-suite-rules miscellaneous-suggestions))))

--- a/default-recommendations/for-loop-shortcuts.rkt
+++ b/default-recommendations/for-loop-shortcuts.rkt
@@ -6,13 +6,15 @@
 
 (provide
  (contract-out
-  [for-loop-shortcuts (listof refactoring-rule?)]))
+  [for-loop-shortcuts refactoring-suite?]))
 
 
 (require (for-syntax racket/base)
          racket/list
          racket/set
+         rebellion/private/static-name
          resyntax/refactoring-rule
+         resyntax/refactoring-suite
          resyntax/default-recommendations/private/lambda-by-any-name
          resyntax/default-recommendations/private/let-binding
          resyntax/default-recommendations/private/syntax-identifier-sets
@@ -157,6 +159,9 @@
 
 
 (define for-loop-shortcuts
-  (list apply-plus-to-for/sum
-        for/fold-building-hash-to-for/hash
-        for-each-to-for))
+  (refactoring-suite
+   #:name (name for-loop-shortcuts)
+   #:rules
+   (list apply-plus-to-for/sum
+         for/fold-building-hash-to-for/hash
+         for-each-to-for)))

--- a/default-recommendations/legacy-contract-migrations.rkt
+++ b/default-recommendations/legacy-contract-migrations.rkt
@@ -6,13 +6,15 @@
 
 (provide
  (contract-out
-  [legacy-contract-migrations (listof refactoring-rule?)]))
+  [legacy-contract-migrations refactoring-suite?]))
 
 
 (require (for-syntax racket/base)
          racket/contract
          racket/syntax
-         resyntax/refactoring-rule)
+         rebellion/private/static-name
+         resyntax/refactoring-rule
+         resyntax/refactoring-suite)
 
 
 ;@----------------------------------------------------------------------------------------------------
@@ -82,11 +84,14 @@
 
 
 (define legacy-contract-migrations
-  (list box-immutable/c-migration
-        contract-struct-migration
-        define-contract-struct-migration
-        false/c-migration
-        flat-contract-migration
-        symbols-migration
-        vector-immutableof-migration
-        vector-immutable/c-migration))
+  (refactoring-suite
+   #:name (name legacy-contract-migrations)
+   #:rules
+   (list box-immutable/c-migration
+         contract-struct-migration
+         define-contract-struct-migration
+         false/c-migration
+         flat-contract-migration
+         symbols-migration
+         vector-immutableof-migration
+         vector-immutable/c-migration)))

--- a/default-recommendations/legacy-struct-migrations.rkt
+++ b/default-recommendations/legacy-struct-migrations.rkt
@@ -6,13 +6,15 @@
 
 (provide
  (contract-out
-  [legacy-struct-migrations (listof refactoring-rule?)]))
+  [legacy-struct-migrations refactoring-suite?]))
 
 
 (require (for-syntax racket/base)
          racket/list
          racket/syntax
+         rebellion/private/static-name
          resyntax/refactoring-rule
+         resyntax/refactoring-suite
          resyntax/syntax-replacement
          syntax/parse)
 
@@ -52,4 +54,4 @@
 
 
 (define legacy-struct-migrations
-  (list define-struct-to-struct))
+  (refactoring-suite #:name (name legacy-struct-migrations) #:rules (list define-struct-to-struct)))

--- a/default-recommendations/let-binding-suggestions.rkt
+++ b/default-recommendations/let-binding-suggestions.rkt
@@ -6,7 +6,7 @@
 
 (provide
  (contract-out
-  [let-binding-suggestions (listof refactoring-rule?)]))
+  [let-binding-suggestions refactoring-suite?]))
 
 
 (require (for-syntax racket/base)
@@ -21,8 +21,10 @@
                   define/public-final
                   define/pubment
                   define/private)
+         rebellion/private/static-name
          resyntax/default-recommendations/private/let-binding
          resyntax/refactoring-rule
+         resyntax/refactoring-suite
          resyntax/default-recommendations/private/lambda-by-any-name
          resyntax/syntax-replacement
          syntax/parse
@@ -169,9 +171,12 @@
 
 
 (define let-binding-suggestions
-  (list let-to-define
-        and-let-to-cond-define
-        cond-let-to-cond-define
-        if-then-let-to-cond-define
-        if-else-let-to-cond-define
-        let*-once-to-let))
+  (refactoring-suite
+   #:name (name let-binding-suggestions)
+   #:rules
+   (list let-to-define
+         and-let-to-cond-define
+         cond-let-to-cond-define
+         if-then-let-to-cond-define
+         if-else-let-to-cond-define
+         let*-once-to-let)))

--- a/default-recommendations/miscellaneous-suggestions.rkt
+++ b/default-recommendations/miscellaneous-suggestions.rkt
@@ -6,35 +6,17 @@
 
 (provide
  (contract-out
-  [miscellaneous-suggestions (listof refactoring-rule?)]))
+  [miscellaneous-suggestions refactoring-suite?]))
 
 
 (require (for-syntax racket/base)
-         (only-in racket/class
-                  define/augment
-                  define/augment-final
-                  define/augride
-                  define/overment
-                  define/override
-                  define/override-final
-                  define/public
-                  define/public-final
-                  define/pubment
-                  define/private)
-         racket/list
          racket/match
-         racket/sequence
-         racket/syntax
-         rebellion/base/immutable-string
-         rebellion/base/option
          rebellion/private/guarded-block
-         rebellion/type/object
+         rebellion/private/static-name
          resyntax/refactoring-rule
-         resyntax/default-recommendations/private/let-binding
+         resyntax/refactoring-suite
          resyntax/syntax-replacement
-         syntax/parse
-         syntax/parse/define
-         syntax/parse/lib/function-header)
+         syntax/parse)
 
 
 ;@----------------------------------------------------------------------------------------------------
@@ -183,16 +165,18 @@
 
 
 (define miscellaneous-suggestions
-  (list and-and-to-and
-        and-match-to-match
-        cond-begin-to-cond
-        cond-else-if-to-cond
-        define-case-lambda-to-define
-        define-lambda-to-define
-        if-then-begin-to-cond
-        if-else-begin-to-cond
-        if-else-cond-to-cond
-        if-else-if-to-cond
-        if-x-else-x-to-and
-        or-cond-to-cond
-        or-or-to-or))
+  (refactoring-suite
+   #:name (name miscellaneous-suggestions)
+   #:rules (list and-and-to-and
+                 and-match-to-match
+                 cond-begin-to-cond
+                 cond-else-if-to-cond
+                 define-case-lambda-to-define
+                 define-lambda-to-define
+                 if-then-begin-to-cond
+                 if-else-begin-to-cond
+                 if-else-cond-to-cond
+                 if-else-if-to-cond
+                 if-x-else-x-to-and
+                 or-cond-to-cond
+                 or-or-to-or)))

--- a/refactoring-suite.rkt
+++ b/refactoring-suite.rkt
@@ -1,0 +1,32 @@
+#lang racket/base
+
+
+(require racket/contract/base)
+
+
+(provide
+ (contract-out
+  [refactoring-suite? predicate/c]
+  [refactoring-suite
+   (->*
+    () (#:rules (sequence/c refactoring-rule?) #:name (or/c interned-symbol? #false))
+    refactoring-suite?)]
+  [refactoring-suite-rules (-> refactoring-suite? (listof refactoring-rule?))]))
+
+
+(require racket/sequence
+         rebellion/base/symbol
+         rebellion/type/object
+         resyntax/refactoring-rule)
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(define-object-type refactoring-suite (rules)
+  #:constructor-name constructor:refactoring-suite
+  #:omit-root-binding)
+
+
+(define (refactoring-suite #:rules [rules '()] #:name [name #false])
+  (constructor:refactoring-suite #:rules (sequence->list rules) #:name name))


### PR DESCRIPTION
To represent groups of rules, this change defines a "refactoring suite" type that's just a simple named wrapper around a list of rules. Closes #53.