### PR TITLE
Split function definition shortcuts into separate suite

### DIFF
--- a/default-recommendations.rkt
+++ b/default-recommendations.rkt
@@ -1,20 +1,27 @@
 #lang racket/base
 
+
 (require racket/contract/base)
 
 
 (provide
+ (all-from-out resyntax/default-recommendations/for-loop-shortcuts
+               resyntax/default-recommendations/function-definition-shortcuts
+               resyntax/default-recommendations/legacy-contract-migrations
+               resyntax/default-recommendations/legacy-struct-migrations
+               resyntax/default-recommendations/let-binding-suggestions
+               resyntax/default-recommendations/miscellaneous-suggestions)
  (contract-out
   [default-recommendations refactoring-suite?]))
 
 
 (require rebellion/private/static-name
          resyntax/default-recommendations/for-loop-shortcuts
+         resyntax/default-recommendations/function-definition-shortcuts
          resyntax/default-recommendations/legacy-contract-migrations
          resyntax/default-recommendations/legacy-struct-migrations
          resyntax/default-recommendations/let-binding-suggestions
          resyntax/default-recommendations/miscellaneous-suggestions
-         resyntax/refactoring-rule
          resyntax/refactoring-suite)
 
 
@@ -26,6 +33,7 @@
    #:name (name default-recommendations)
    #:rules
    (append (refactoring-suite-rules for-loop-shortcuts)
+           (refactoring-suite-rules function-definition-shortcuts)
            (refactoring-suite-rules legacy-contract-migrations)
            (refactoring-suite-rules legacy-struct-migrations)
            (refactoring-suite-rules let-binding-suggestions)

--- a/default-recommendations/for-loop-shortcuts-test.rkt
+++ b/default-recommendations/for-loop-shortcuts-test.rkt
@@ -1,7 +1,7 @@
 #lang resyntax/testing/refactoring-test
 
 
-require: resyntax/default-recommendations/for-loop-shortcuts for-loop-shortcuts
+require: resyntax/default-recommendations for-loop-shortcuts
 
 
 test: "for-each with short single-form body not refactorable"

--- a/default-recommendations/function-definition-shortcuts-test.rkt
+++ b/default-recommendations/function-definition-shortcuts-test.rkt
@@ -1,0 +1,102 @@
+#lang resyntax/testing/refactoring-test
+
+
+require: resyntax/default-recommendations function-definition-shortcuts
+
+
+test: "lambda variable definition to function definition"
+------------------------------
+#lang racket/base
+(define f
+  (λ (a b c)
+    1))
+------------------------------
+#lang racket/base
+(define (f a b c)
+  1)
+------------------------------
+
+
+test: "lambda variable definition with only rest argument to function definition"
+------------------------------
+#lang racket/base
+(define f
+  (λ xs
+    1))
+------------------------------
+#lang racket/base
+(define (f . xs)
+  1)
+------------------------------
+
+
+test: "lambda variable definition with rest argument to function definition"
+------------------------------
+#lang racket/base
+(define f
+  (λ (a b c . xs)
+    1))
+------------------------------
+#lang racket/base
+(define (f a b c . xs)
+  1)
+------------------------------
+
+
+test: "lambda function definition to function definition"
+------------------------------
+#lang racket/base
+(define (f a b c)
+  (λ (x y z)
+    1))
+------------------------------
+#lang racket/base
+(define ((f a b c) x y z)
+  1)
+------------------------------
+
+
+test: "lambda function definition with closed-over expressions not refactorable"
+------------------------------
+#lang racket/base
+(define (f a b c)
+  (displayln a)
+  (λ (x y z)
+    1))
+------------------------------
+
+
+test: "lambda variable definition with long header to function definition with preserved formatting"
+------------------------------
+#lang racket/base
+(define f
+  (λ (a
+      b
+      c)
+    1))
+------------------------------
+#lang racket/base
+(define (f a
+           b
+           c)
+  1)
+------------------------------
+
+
+test: "lambda variable definition with commented body to definition with preserved comments"
+------------------------------
+#lang racket/base
+(define f
+  (λ (a)
+    ;; comment before all body forms
+    (void)
+    ;; comment before last body form
+    1))
+------------------------------
+#lang racket/base
+(define (f a)
+  ;; comment before all body forms
+  (void)
+  ;; comment before last body form
+  1)
+------------------------------

--- a/default-recommendations/function-definition-shortcuts-test.rkt
+++ b/default-recommendations/function-definition-shortcuts-test.rkt
@@ -17,6 +17,19 @@ test: "lambda variable definition to function definition"
 ------------------------------
 
 
+test: "lambda variable definition with no arguments to function definition"
+------------------------------
+#lang racket/base
+(define f
+  (λ ()
+    1))
+------------------------------
+#lang racket/base
+(define (f)
+  1)
+------------------------------
+
+
 test: "lambda variable definition with only rest argument to function definition"
 ------------------------------
 #lang racket/base

--- a/default-recommendations/function-definition-shortcuts.rkt
+++ b/default-recommendations/function-definition-shortcuts.rkt
@@ -36,7 +36,10 @@
 
   (pattern converted:id)
 
-  (pattern (formal ...)
+  (pattern ()
+    #:with converted #'())
+
+  (pattern (formal ...+)
     #:with converted #'((ORIGINAL-SPLICE formal ...)))
 
   (pattern (formal ... . rest-arg:id)

--- a/default-recommendations/function-definition-shortcuts.rkt
+++ b/default-recommendations/function-definition-shortcuts.rkt
@@ -1,0 +1,75 @@
+#lang racket/base
+
+
+(require racket/contract/base)
+
+
+(provide
+ (contract-out
+  [function-definition-shortcuts refactoring-suite?]))
+
+
+(require (for-syntax racket/base)
+         rebellion/private/guarded-block
+         rebellion/private/static-name
+         resyntax/default-recommendations/private/lambda-by-any-name
+         resyntax/refactoring-rule
+         resyntax/refactoring-suite
+         resyntax/syntax-replacement
+         syntax/parse)
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(define/guard (free-identifiers=? ids other-ids)
+  (define id-list (syntax->list ids))
+  (define other-id-list (syntax->list other-ids))
+  (guard (equal? (length id-list) (length other-id-list)) else
+    #false)
+  (for/and ([id (in-list id-list)] [other-id (in-list other-id-list)])
+    (free-identifier=? id other-id)))
+
+
+(define-syntax-class lambda-header
+  #:attributes (converted)
+
+  (pattern converted:id)
+
+  (pattern (formal ...)
+    #:with converted #'((ORIGINAL-SPLICE formal ...)))
+
+  (pattern (formal ... . rest-arg:id)
+    #:with converted #'((ORIGINAL-SPLICE formal ... rest-arg))))
+
+
+(define-refactoring-rule define-lambda-to-define
+  #:description "The define form supports a shorthand for defining functions."
+  #:literals (define)
+  [(define header (_:lambda-by-any-name formals:lambda-header initial-body body ...))
+   (define (header . formals.converted)
+     (ORIGINAL-GAP formals initial-body)
+     (ORIGINAL-SPLICE initial-body body ...))])
+
+
+(define-refactoring-rule define-case-lambda-to-define
+  #:description "This use of case-lambda is equivalent to using define with optional arguments."
+  #:literals (define case-lambda)
+  [(define id:id
+     (case-lambda
+       [(case1-arg:id ...)
+        (usage:id usage1:id ... default:expr)]
+       [(case2-arg:id ... bonus-arg:id)
+        body ...]))
+   #:when (free-identifier=? #'id #'usage)
+   #:when (free-identifiers=? #'(case1-arg ...) #'(case2-arg ...))
+   #:when (free-identifiers=? #'(case1-arg ...) #'(usage1 ...))
+   (define (id case2-arg ... [bonus-arg default])
+     (~@ NEWLINE body) ...)])
+
+
+(define function-definition-shortcuts
+  (refactoring-suite
+   #:name (name function-definition-shortcuts)
+   #:rules (list define-lambda-to-define
+                 define-case-lambda-to-define)))

--- a/default-recommendations/legacy-struct-migrations-test.rkt
+++ b/default-recommendations/legacy-struct-migrations-test.rkt
@@ -1,6 +1,6 @@
 #lang resyntax/testing/refactoring-test
 
-require: resyntax/default-recommendations/legacy-struct-migrations legacy-struct-migrations
+require: resyntax/default-recommendations legacy-struct-migrations
 
 
 test: "define-struct without options"

--- a/default-recommendations/let-binding-suggestions-comment-test.rkt
+++ b/default-recommendations/let-binding-suggestions-comment-test.rkt
@@ -1,7 +1,7 @@
 #lang resyntax/testing/refactoring-test
 
 
-require: resyntax/default-recommendations/let-binding-suggestions let-binding-suggestions
+require: resyntax/default-recommendations let-binding-suggestions
 
 
 test: "let binding with commented right-hand-side expression"

--- a/default-recommendations/let-binding-suggestions-function-shortcuts-test.rkt
+++ b/default-recommendations/let-binding-suggestions-function-shortcuts-test.rkt
@@ -1,7 +1,7 @@
 #lang resyntax/testing/refactoring-test
 
 
-require: resyntax/default-recommendations/let-binding-suggestions let-binding-suggestions
+require: resyntax/default-recommendations let-binding-suggestions
 
 
 test: "let binding to lambda"

--- a/default-recommendations/let-binding-suggestions-test.rkt
+++ b/default-recommendations/let-binding-suggestions-test.rkt
@@ -1,7 +1,7 @@
 #lang resyntax/testing/refactoring-test
 
 
-require: resyntax/default-recommendations/let-binding-suggestions let-binding-suggestions
+require: resyntax/default-recommendations let-binding-suggestions
 
 
 test: "single let binding"

--- a/default-recommendations/miscellaneous-suggestions.rkt
+++ b/default-recommendations/miscellaneous-suggestions.rkt
@@ -22,38 +22,6 @@
 ;@----------------------------------------------------------------------------------------------------
 
 
-(define/guard (free-identifiers=? ids other-ids)
-  (define id-list (syntax->list ids))
-  (define other-id-list (syntax->list other-ids))
-  (guard (equal? (length id-list) (length other-id-list)) else
-    #false)
-  (for/and ([id (in-list id-list)] [other-id (in-list other-id-list)])
-    (free-identifier=? id other-id)))
-
-
-(define-refactoring-rule define-lambda-to-define
-  #:description "The define form supports a shorthand for defining functions."
-  #:literals (define lambda)
-  [(define header (lambda formals body ...))
-   (define (header . formals) (~@ NEWLINE body) ...)])
-
-
-(define-refactoring-rule define-case-lambda-to-define
-  #:description "This use of case-lambda is equivalent to using define with optional arguments."
-  #:literals (define case-lambda)
-  [(define id:id
-     (case-lambda
-       [(case1-arg:id ...)
-        (usage:id usage1:id ... default:expr)]
-       [(case2-arg:id ... bonus-arg:id)
-        body ...]))
-   #:when (free-identifier=? #'id #'usage)
-   #:when (free-identifiers=? #'(case1-arg ...) #'(case2-arg ...))
-   #:when (free-identifiers=? #'(case1-arg ...) #'(usage1 ...))
-   (define (id case2-arg ... [bonus-arg default])
-     (~@ NEWLINE body) ...)])
-
-
 (define if-begin-to-cond-message
   "The cond form supports multiple body expressions in each branch, making begin unnecessary.")
 
@@ -171,8 +139,6 @@
                  and-match-to-match
                  cond-begin-to-cond
                  cond-else-if-to-cond
-                 define-case-lambda-to-define
-                 define-lambda-to-define
                  if-then-begin-to-cond
                  if-else-begin-to-cond
                  if-else-cond-to-cond

--- a/syntax-replacement.rkt
+++ b/syntax-replacement.rkt
@@ -1,10 +1,11 @@
-#lang racket/base
+#lang debug racket/base
 
 
 (require racket/contract/base)
 
 
 (provide
+ SPACE
  NEWLINE
  ORIGINAL-GAP
  ORIGINAL-SPLICE
@@ -45,6 +46,13 @@
    stx))
 
 
+(define-syntax (SPACE stx)
+  (raise-syntax-error
+   #false
+   "should only be used by refactoring rules to indicate where a space should be inserted"
+   stx))
+
+
 (define-syntax (ORIGINAL-GAP stx)
   (raise-syntax-error
    #false
@@ -70,6 +78,68 @@
 (define-record-type syntax-replacement (original-syntax new-syntax))
 
 
+(define/guard (syntax-replacement-template-infer-spaces template)
+  (define/guard (loop template)
+    (guard (syntax-original? template) then
+      template)
+    (syntax-parse template
+      #:literals (quote NEWLINE SPACE ORIGINAL-GAP ORIGINAL-SPLICE)
+      [(~or (ORIGINAL-GAP _ ...) (ORIGINAL-SPLICE _ ...) (quote _ ...)) template]
+      [(subform ...)
+       (define (contents-to-add-between left-form right-form)
+         (if (or (template-separator? left-form) (template-separator? right-form))
+             '()
+             (list #'SPACE)))
+       (define subforms-with-spaces
+         (for/list ([subform-stx (in-syntax #'(subform ...))])
+           (loop subform-stx)))
+       (datum->syntax #false (add-contents-between subforms-with-spaces contents-to-add-between))]
+      [else template]))
+  (define flip-fresh-scope (make-syntax-introducer))
+  (flip-fresh-scope (loop (flip-fresh-scope template))))
+
+
+(define (template-separator? stx)
+  (syntax-parse stx
+    #:literals (NEWLINE SPACE ORIGINAL-GAP)
+    [(~or NEWLINE SPACE (ORIGINAL-GAP _ ...)) #true]
+    [else #false]))
+
+
+(define/guard (add-contents-between lst adder)
+  (guard (empty? lst) then
+    '())
+  (define first-element (first lst))
+  (cons
+   first-element
+   (for/list ([previous (in-list lst)]
+              [element (in-list (rest lst))]
+              #:when #true
+              [inserted (append (adder previous element) (list element))])
+     inserted)))
+
+
+(module+ test
+  (test-case (name-string add-contents-between)
+
+    (define (appended-strings left right)
+      (list (format "left: ~a" left) (format "right: ~a" right)))
+    
+    (test-case "empty list"
+      (check-equal? (add-contents-between '() appended-strings) '()))
+
+    (test-case "singleton list"
+      (check-equal? (add-contents-between (list 1) appended-strings) (list 1)))
+
+    (test-case "two-element list"
+      (define actual (add-contents-between (list 1 2) appended-strings))
+      (check-equal? actual (list 1 "left: 1" "right: 2" 2)))
+
+    (test-case "many-element list"
+      (define actual (add-contents-between (list 1 2 3) appended-strings))
+      (check-equal? actual (list 1 "left: 1" "right: 2" 2 "left: 2" "right: 3" 3)))))
+
+
 (define/guard (syntax-replacement-render replacement)
 
   (define/guard (pieces stx)
@@ -78,12 +148,17 @@
       (define end (+ start (syntax-span stx)))
       (list (copied-string start end)))
     (syntax-parse stx
-      #:literals (quote NEWLINE ORIGINAL-GAP ORIGINAL-SPLICE)
+      #:literals (quote SPACE NEWLINE ORIGINAL-GAP ORIGINAL-SPLICE)
+
+      [SPACE (list (inserted-string " "))]
+      
       [NEWLINE (list (inserted-string "\n"))]
+
       [(ORIGINAL-GAP ~! before after)
        (define before-end (+ (sub1 (syntax-position #'before)) (syntax-span #'before)))
        (define after-start (sub1 (syntax-position #'after)))
        (list (copied-string before-end after-start))]
+      
       [(ORIGINAL-SPLICE ~! original-subform ...+)
        (define subforms (syntax->list #'(original-subform ...)))
        (for ([subform-stx (in-list subforms)])
@@ -96,17 +171,23 @@
        (define start (sub1 (syntax-position (first subforms))))
        (define end (+ (sub1 (syntax-position (last subforms))) (syntax-span (last subforms))))
        (list (copied-string start end))]
+      
       [(~or v:id v:boolean v:char v:keyword v:number v:regexp v:byte-regexp v:string v:bytes)
        (list (inserted-string (string->immutable-string (~s (syntax-e #'v)))))]
+      
       [(quote datum) (cons (inserted-string "'") (pieces #'datum))]
+      
       [(subform ...)
        (define shape (syntax-property stx 'paren-shape))
        (define opener (match shape [#false "("] [#\[ "["] [#\{ "{"]))
        (define closer (match shape [#false ")"] [#\[ "]"] [#\{ "}"]))
        (append
         (list (inserted-string opener))
-        (join-piece-lists (for/list ([subform-stx (in-syntax #'(subform ...))]) (pieces subform-stx)))
+        (for*/list ([subform-stx (in-syntax #'(subform ...))]
+                    [piece (in-list (pieces subform-stx))])
+          piece)
         (list (inserted-string closer)))]
+      
       [(subform ... . tail-form)
        (define shape (syntax-property stx 'paren-shape))
        (define opener (match shape [#false "("] [#\[ "["] [#\{ "{"]))
@@ -129,9 +210,10 @@
         (list (inserted-string closer)))]))
 
   (match-define (syntax-replacement #:original-syntax orig-stx #:new-syntax new-stx) replacement)
+  (define template (syntax-replacement-template-infer-spaces new-stx))
   (define start (sub1 (syntax-position orig-stx)))
   (string-replacement
-   #:start start #:end (+ start (syntax-span orig-stx)) #:contents (pieces new-stx)))
+   #:start start #:end (+ start (syntax-span orig-stx)) #:contents (pieces template)))
 
 
 (define/guard (ends-with-newline? piece-list)

--- a/syntax-replacement.rkt
+++ b/syntax-replacement.rkt
@@ -1,4 +1,4 @@
-#lang debug racket/base
+#lang racket/base
 
 
 (require racket/contract/base)

--- a/syntax-replacement.rkt
+++ b/syntax-replacement.rkt
@@ -79,22 +79,29 @@
 
 
 (define/guard (syntax-replacement-template-infer-spaces template)
+
   (define/guard (loop template)
     (guard (syntax-original? template) then
       template)
     (syntax-parse template
       #:literals (quote NEWLINE SPACE ORIGINAL-GAP ORIGINAL-SPLICE)
+
       [(~or (ORIGINAL-GAP _ ...) (ORIGINAL-SPLICE _ ...) (quote _ ...)) template]
+      
       [(subform ...)
        (define (contents-to-add-between left-form right-form)
          (if (or (template-separator? left-form) (template-separator? right-form))
              '()
              (list #'SPACE)))
-       (define subforms-with-spaces
+       (define subforms-with-spaces-inside
          (for/list ([subform-stx (in-syntax #'(subform ...))])
            (loop subform-stx)))
-       (datum->syntax #false (add-contents-between subforms-with-spaces contents-to-add-between))]
+       (define subforms-with-spaces-between
+         (add-contents-between subforms-with-spaces-inside contents-to-add-between))
+       (datum->syntax #false subforms-with-spaces-between template template)]
+      
       [else template]))
+  
   (define flip-fresh-scope (make-syntax-introducer))
   (flip-fresh-scope (loop (flip-fresh-scope template))))
 


### PR DESCRIPTION
Additionally:
- Add more tests.
- Implement better whitespace inference between subforms when rendering syntax replacement templates.
- Reprovide refactoring suites from `resyntax/default-recommendations` to make them easier to import in the CLI and tests.