### PR TITLE
Cut back on let binding suggestions.

### DIFF
--- a/default-recommendations/let-binding-suggestions-test.rkt
+++ b/default-recommendations/let-binding-suggestions-test.rkt
@@ -119,3 +119,137 @@ test: "self-shadowing let-values binding clause isn't refactorable"
   (let-values ([(x y) (values x 1)])
     1))
 ------------------------------
+
+
+test: "let forms inside lambdas"
+------------------------------
+#lang racket/base
+(λ ()
+  (let ([x 1])
+    1))
+------------------------------
+#lang racket/base
+(λ ()
+  (define x 1)
+  1)
+------------------------------
+
+
+test: "let forms inside unrefactorable let forms"
+------------------------------
+#lang racket/base
+(define a 1)
+(let ([a a])
+  (let ([x 1])
+    1))
+------------------------------
+#lang racket/base
+(define a 1)
+(let ([a a])
+  (define x 1)
+  1)
+------------------------------
+
+
+test: "let forms inside let loops"
+------------------------------
+#lang racket/base
+(let loop ()
+  (let ([x 1])
+    1))
+------------------------------
+#lang racket/base
+(let loop ()
+  (define x 1)
+  1)
+------------------------------
+
+
+test: "let forms inside unrefactorable let* forms"
+------------------------------
+#lang racket/base
+(define a 1)
+(let* ([a a]
+       [a a])
+  (let ([x 1])
+    1))
+------------------------------
+#lang racket/base
+(define a 1)
+(let* ([a a]
+       [a a])
+  (define x 1)
+  1)
+------------------------------
+
+
+test: "let forms inside unrefactorable let-values forms"
+------------------------------
+#lang racket/base
+(define a 1)
+(let-values ([(a b) (values a 1)])
+  (let ([x 1])
+    1))
+------------------------------
+#lang racket/base
+(define a 1)
+(let-values ([(a b) (values a 1)])
+  (define x 1)
+  1)
+------------------------------
+
+
+test: "let forms inside when forms"
+------------------------------
+#lang racket/base
+(when #true
+  (let ([x 1])
+    1))
+------------------------------
+#lang racket/base
+(when #true
+  (define x 1)
+  1)
+------------------------------
+
+
+test: "let forms inside unless forms"
+------------------------------
+#lang racket/base
+(unless #false
+  (let ([x 1])
+    1))
+------------------------------
+#lang racket/base
+(unless #false
+  (define x 1)
+  1)
+------------------------------
+
+
+test: "let forms inside with-handlers forms"
+------------------------------
+#lang racket/base
+(with-handlers ([exn:fail? void])
+  (let ([x 1])
+    1))
+------------------------------
+#lang racket/base
+(with-handlers ([exn:fail? void])
+  (define x 1)
+  1)
+------------------------------
+
+
+test: "let forms inside parameterize forms"
+------------------------------
+#lang racket/base
+(parameterize ([current-output-port #false])
+  (let ([x 1])
+    1))
+------------------------------
+#lang racket/base
+(parameterize ([current-output-port #false])
+  (define x 1)
+  1)
+------------------------------


### PR DESCRIPTION
Only make suggestions when let forms can be fully migrated, and stop suggesting changing code to use `cond` to simplify let forms. In fact, stop making suggestions about `cond` altogether, since the current rules for `cond` aren't good enough at preserving comments and minimizing the number of passes.

This change also fixes a bug where let expressions in `when`, `unless`, `with-handlers`, and `parameterize` forms weren't migrated.

Closes #58.