### PR TITLE
Add boolean shortcuts for flattening nested ors and ands

### DIFF
--- a/default-recommendations.rkt
+++ b/default-recommendations.rkt
@@ -5,7 +5,8 @@
 
 
 (provide
- (all-from-out resyntax/default-recommendations/for-loop-shortcuts
+ (all-from-out resyntax/default-recommendations/boolean-shortcuts
+               resyntax/default-recommendations/for-loop-shortcuts
                resyntax/default-recommendations/function-definition-shortcuts
                resyntax/default-recommendations/legacy-contract-migrations
                resyntax/default-recommendations/legacy-struct-migrations
@@ -17,6 +18,7 @@
 
 
 (require rebellion/private/static-name
+         resyntax/default-recommendations/boolean-shortcuts
          resyntax/default-recommendations/for-loop-shortcuts
          resyntax/default-recommendations/function-definition-shortcuts
          resyntax/default-recommendations/legacy-contract-migrations
@@ -34,7 +36,8 @@
   (refactoring-suite
    #:name (name default-recommendations)
    #:rules
-   (append (refactoring-suite-rules for-loop-shortcuts)
+   (append (refactoring-suite-rules boolean-shortcuts)
+           (refactoring-suite-rules for-loop-shortcuts)
            (refactoring-suite-rules function-definition-shortcuts)
            (refactoring-suite-rules legacy-contract-migrations)
            (refactoring-suite-rules legacy-struct-migrations)

--- a/default-recommendations/boolean-shortcuts-test.rkt
+++ b/default-recommendations/boolean-shortcuts-test.rkt
@@ -1,0 +1,114 @@
+#lang resyntax/testing/refactoring-test
+
+
+require: resyntax/default-recommendations boolean-shortcuts
+
+
+test: "nested ors can be flattened"
+------------------------------
+#lang racket/base
+(or 1 2 (or 3 4))
+------------------------------
+#lang racket/base
+(or 1 2 3 4)
+------------------------------
+
+
+test: "flat ors can't be flattened"
+------------------------------
+#lang racket/base
+(or 1 2 3)
+------------------------------
+
+
+test: "multiple nested ors can be flattened at once"
+------------------------------
+#lang racket/base
+(or (or 1 2) (or 3 4) (or 5 6))
+------------------------------
+#lang racket/base
+(or 1 2 3 4 5 6)
+------------------------------
+
+
+test: "deeply nested ors can be flattened in one pass"
+------------------------------
+#lang racket/base
+(or 1 (or 2 (or 3 (or 4 5 6))))
+------------------------------
+#lang racket/base
+(or 1 2 3 4 5 6)
+------------------------------
+
+
+test: "multiline nested ors can't be flattened"
+------------------------------
+#lang racket/base
+(or 1
+    (or 2 3))
+------------------------------
+
+
+test: "nested ands can be flattened"
+------------------------------
+#lang racket/base
+(and 1 2 (and 3 4))
+------------------------------
+#lang racket/base
+(and 1 2 3 4)
+------------------------------
+
+
+test: "flat ands can't be flattened"
+------------------------------
+#lang racket/base
+(and 1 2 3)
+------------------------------
+
+
+test: "multiple nested ands can be flattened at once"
+------------------------------
+#lang racket/base
+(and (and 1 2) (and 3 4) (and 5 6))
+------------------------------
+#lang racket/base
+(and 1 2 3 4 5 6)
+------------------------------
+
+
+test: "deeply nested ands can be flattened in one pass"
+------------------------------
+#lang racket/base
+(and 1 (and 2 (and 3 (and 4 5 6))))
+------------------------------
+#lang racket/base
+(and 1 2 3 4 5 6)
+------------------------------
+
+
+test: "multiline nested ands can't be flattened"
+------------------------------
+#lang racket/base
+(and 1
+     (and 2 3))
+------------------------------
+
+
+test: "nested ors interspersed with ands can be flattened"
+------------------------------
+#lang racket/base
+(or (or 1 2) (and 3 4) (or 5 6))
+------------------------------
+#lang racket/base
+(or 1 2 (and 3 4) 5 6)
+------------------------------
+
+
+test: "nested ands interspersed with ors can be flattened"
+------------------------------
+#lang racket/base
+(and (and 1 2) (or 3 4) (and 5 6))
+------------------------------
+#lang racket/base
+(and 1 2 (or 3 4) 5 6)
+------------------------------

--- a/default-recommendations/boolean-shortcuts.rkt
+++ b/default-recommendations/boolean-shortcuts.rkt
@@ -1,0 +1,50 @@
+#lang racket/base
+
+
+(require racket/contract/base)
+
+
+(provide
+ (contract-out
+  [boolean-shortcuts refactoring-suite?]))
+
+
+(require (for-syntax racket/base)
+         racket/list
+         rebellion/private/static-name
+         resyntax/default-recommendations/private/syntax-lines
+         resyntax/default-recommendations/private/syntax-tree
+         resyntax/refactoring-rule
+         resyntax/refactoring-suite
+         syntax/parse)
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(define-refactoring-rule nested-or-to-flat-or
+  #:description "Nested or expressions can be flattened to a single, equivalent or expression."
+  [or-tree
+   #:declare or-tree (syntax-tree #'or)
+   ;; Restricted to single-line expressions for now because the syntax-tree operations don't preserve
+   ;; any formatting between adjacent leaves.
+   #:when (oneline-syntax? #'or-tree)
+   #:when (>= (attribute or-tree.rank) 2)
+   (or or-tree.leaf ...)])
+
+
+(define-refactoring-rule nested-and-to-flat-and
+  #:description "Nested and expressions can be flattened to a single, equivalent and expression."
+  [and-tree
+   #:declare and-tree (syntax-tree #'and)
+   ;; Restricted to single-line expressions for now because the syntax-tree operations don't preserve
+   ;; any formatting between adjacent leaves.
+   #:when (oneline-syntax? #'and-tree)
+   #:when (>= (attribute and-tree.rank) 2)
+   (and and-tree.leaf ...)])
+
+
+(define boolean-shortcuts
+  (refactoring-suite
+   #:name (name boolean-shortcuts)
+   #:rules (list nested-and-to-flat-and nested-or-to-flat-or)))

--- a/default-recommendations/miscellaneous-suggestions.rkt
+++ b/default-recommendations/miscellaneous-suggestions.rkt
@@ -103,24 +103,6 @@
      (~@ NEWLINE clause) ...)])
 
 
-(define-refactoring-rule or-or-to-or
-  #:description "Nested or expressions are equivalent to a single or expression."
-  #:literals (or)
-  [(or first-clause clause ... (or inner-clause ...))
-   (or first-clause
-       (~@ NEWLINE clause) ...
-       (~@ NEWLINE inner-clause) ...)])
-
-
-(define-refactoring-rule and-and-to-and
-  #:description "Nested and expressions are equivalent to a single and expression."
-  #:literals (and)
-  [(and first-clause clause ... (and inner-clause ...))
-   (and first-clause
-        (~@ NEWLINE clause) ...
-        (~@ NEWLINE inner-clause) ...)])
-
-
 (define-refactoring-rule and-match-to-match
   #:description "This and expression can be turned into a clause of the inner match expression,\
  reducing nesting."
@@ -135,8 +117,7 @@
 (define miscellaneous-suggestions
   (refactoring-suite
    #:name (name miscellaneous-suggestions)
-   #:rules (list and-and-to-and
-                 and-match-to-match
+   #:rules (list and-match-to-match
                  cond-begin-to-cond
                  cond-else-if-to-cond
                  if-then-begin-to-cond
@@ -144,5 +125,4 @@
                  if-else-cond-to-cond
                  if-else-if-to-cond
                  if-x-else-x-to-and
-                 or-cond-to-cond
-                 or-or-to-or)))
+                 or-cond-to-cond)))

--- a/default-recommendations/private/syntax-tree.rkt
+++ b/default-recommendations/private/syntax-tree.rkt
@@ -1,0 +1,103 @@
+#lang racket/base
+
+
+;; This module defines a syntax-tree syntax class for recognizing trees of nested expressions. It's
+;; primarily intended for implementing various tree-flattening refactoring rules that rewrite forms
+;; like (or a b (or c d) e) to (or a b c d e). The syntax class accepts an identifier that determines
+;; what subforms count as branches, and it parses out the leaves of the tree. It also makes the rank
+;; of the tree (the number of levels in the tree) available as an attribute, so that the flattening
+;; refactoring rules can avoid flattening trees that are already flat.
+
+
+(provide syntax-tree)
+
+
+(require rebellion/base/option
+         rebellion/streaming/reducer
+         rebellion/streaming/transducer
+         syntax/parse)
+
+
+(module+ test
+  (require (submod "..")
+           rackunit))
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(define-syntax-class (syntax-tree branch-identifier)
+  #:attributes ([leaf 1] rank)
+  #:commit
+
+  (pattern (id:id subtree ...)
+    #:declare subtree (syntax-tree branch-identifier)
+    #:when (free-identifier=? #'id branch-identifier)
+    #:cut
+    #:with (leaf ...) #'(subtree.leaf ... ...)
+    #:attr rank (add1 (option-get (transduce (attribute subtree.rank) #:into (into-max)) 0)))
+
+  (pattern other
+    #:with (leaf ...) #'(other)
+    #:attr rank 0))
+
+
+(module+ test
+  (test-case "expression-tree"
+
+    (define (leaves stx)
+      (syntax-parse stx
+        [expr
+         #:declare expr (syntax-tree #'or)
+         (syntax->datum #'(expr.leaf ...))]))
+
+    (define (rank stx)
+      (syntax-parse stx
+        [expr
+         #:declare expr (syntax-tree #'or)
+         (attribute expr.rank)]))
+
+    (test-case "no outer form"
+      (define stx #'foo)
+      (check-equal? (leaves stx) '(foo))
+      (check-equal? (rank stx) 0))
+
+    (test-case "unrelated outer form"
+      (define stx #'(foo a b c))
+      (check-equal? (leaves stx) '((foo a b c)))
+      (check-equal? (rank stx) 0))
+
+    (test-case "empty outer form"
+      (define stx #'(or))
+      (check-equal? (leaves stx) '())
+      (check-equal? (rank stx) 1))
+
+    (test-case "flat outer form"
+      (define stx #'(or a b c))
+      (check-equal? (leaves stx) '(a b c))
+      (check-equal? (rank stx) 1))
+
+    (test-case "empty subform in empty outer form"
+      (define stx #'(or (or)))
+      (check-equal? (leaves stx) '())
+      (check-equal? (rank stx) 2))
+
+    (test-case "empty subform"
+      (define stx #'(or a (or) b))
+      (check-equal? (leaves stx) '(a b))
+      (check-equal? (rank stx) 2))
+
+    (test-case "two singleton subforms"
+      (define stx #'(or (or a) (or b)))
+      (check-equal? (leaves stx) '(a b))
+      (check-equal? (rank stx) 2))
+
+    (test-case "two subforms"
+      (define stx #'(or (or a b c) (or a b c)))
+      (check-equal? (leaves stx) '(a b c a b c))
+      (check-equal? (rank stx) 2))
+
+    (test-case "deeply nested subforms"
+      (define stx #'(or a (or b (or c (or d)))))
+      (check-equal? (leaves stx) '(a b c d))
+      (check-equal? (rank stx) 4))))


### PR DESCRIPTION
These rules already existed in the `miscellaneous-suggestions` suite, but they weren't very robust. This makes them slightly more robust and easier to generalize.