### PR TITLE
Refactor (list) to '()

### DIFF
--- a/default-recommendations/list-shortcuts-test.rkt
+++ b/default-recommendations/list-shortcuts-test.rkt
@@ -111,3 +111,13 @@ test: "list equal? to null refactorable to null? check"
 #lang racket/base
 (null? (list 1 2 3))
 ------------------------------
+
+
+test: "(list) refactorable to '() check"
+------------------------------
+#lang racket/base
+(list)
+------------------------------
+#lang racket/base
+'()
+------------------------------

--- a/default-recommendations/list-shortcuts.rkt
+++ b/default-recommendations/list-shortcuts.rkt
@@ -41,7 +41,15 @@
   [test:null-test (null? test.subject)])
 
 
+(define-refactoring-rule list-call-to-empty-list-literal
+  #:description "An empty list literal can be written as '()."
+  #:literals (list)
+  [(list)
+   '()])
+
+
 (define list-shortcuts
   (refactoring-suite
    #:name (name list-shortcuts)
-   #:rules (list equal-null-list-to-null-predicate first-reverse-to-last)))
+   #:rules (list equal-null-list-to-null-predicate first-reverse-to-last
+                 list-call-to-empty-list-literal)))


### PR DESCRIPTION
Adds a new refactoring rule named `list-call-to-empty-list-literal` which refactors calls to `(list)` with no arguments to the empty list literal `'()`.