### PR TITLE
Add nested-if-to-cond rule

### DIFF
--- a/default-recommendations.rkt
+++ b/default-recommendations.rkt
@@ -11,6 +11,7 @@
                resyntax/default-recommendations/legacy-contract-migrations
                resyntax/default-recommendations/legacy-struct-migrations
                resyntax/default-recommendations/let-binding-suggestions
+               resyntax/default-recommendations/conditional-suggestions
                resyntax/default-recommendations/list-shortcuts
                resyntax/default-recommendations/miscellaneous-suggestions)
  (contract-out
@@ -24,6 +25,7 @@
          resyntax/default-recommendations/legacy-contract-migrations
          resyntax/default-recommendations/legacy-struct-migrations
          resyntax/default-recommendations/let-binding-suggestions
+         resyntax/default-recommendations/conditional-suggestions
          resyntax/default-recommendations/list-shortcuts
          resyntax/default-recommendations/miscellaneous-suggestions
          resyntax/refactoring-suite)

--- a/default-recommendations.rkt
+++ b/default-recommendations.rkt
@@ -6,12 +6,12 @@
 
 (provide
  (all-from-out resyntax/default-recommendations/boolean-shortcuts
+               resyntax/default-recommendations/conditional-suggestions
                resyntax/default-recommendations/for-loop-shortcuts
                resyntax/default-recommendations/function-definition-shortcuts
                resyntax/default-recommendations/legacy-contract-migrations
                resyntax/default-recommendations/legacy-struct-migrations
                resyntax/default-recommendations/let-binding-suggestions
-               resyntax/default-recommendations/conditional-suggestions
                resyntax/default-recommendations/list-shortcuts
                resyntax/default-recommendations/miscellaneous-suggestions)
  (contract-out
@@ -20,12 +20,12 @@
 
 (require rebellion/private/static-name
          resyntax/default-recommendations/boolean-shortcuts
+         resyntax/default-recommendations/conditional-suggestions
          resyntax/default-recommendations/for-loop-shortcuts
          resyntax/default-recommendations/function-definition-shortcuts
          resyntax/default-recommendations/legacy-contract-migrations
          resyntax/default-recommendations/legacy-struct-migrations
          resyntax/default-recommendations/let-binding-suggestions
-         resyntax/default-recommendations/conditional-suggestions
          resyntax/default-recommendations/list-shortcuts
          resyntax/default-recommendations/miscellaneous-suggestions
          resyntax/refactoring-suite)
@@ -39,6 +39,7 @@
    #:name (name default-recommendations)
    #:rules
    (append (refactoring-suite-rules boolean-shortcuts)
+           (refactoring-suite-rules conditional-suggestions)
            (refactoring-suite-rules for-loop-shortcuts)
            (refactoring-suite-rules function-definition-shortcuts)
            (refactoring-suite-rules legacy-contract-migrations)

--- a/default-recommendations/conditional-suggestions-test.rkt
+++ b/default-recommendations/conditional-suggestions-test.rkt
@@ -4,24 +4,53 @@
 require: resyntax/default-recommendations conditional-suggestions
 
 
-test: "if-else *doesn't* refactor to cond"
+test: "if without nested ifs not refactorable"
 ------------------------------
 #lang racket/base
 (if 'cond 'then 'else)
 ------------------------------
 
 
-test: "singly-nested if-else *doesn't* refactor to cond"
+test: "singly-nested ifs refactorable to cond"
 ------------------------------
 #lang racket/base
 (if 'cond 'then (if 'cond2 'then2 'else))
 ------------------------------
+#lang racket/base
+(cond
+  ['cond 'then]
+  ['cond2 'then2]
+  [else 'else])
+------------------------------
 
 
-test: "if-else chain refactors to cond"
+test: "one-line nested ifs refactorable to cond"
 ------------------------------
 #lang racket/base
 (if 'a 'b (if 'c 'd (if 'e 'f (if 'g 'h 'i))))
+------------------------------
+#lang racket/base
+(cond
+  ['a 'b]
+  ['c 'd]
+  ['e 'f]
+  ['g 'h]
+  [else 'i])
+------------------------------
+
+
+test: "multi-line nested ifs refactorable to cond"
+------------------------------
+#lang racket/base
+(if 'a
+    'b
+    (if 'c
+        'd
+        (if 'e
+            'f
+            (if 'g
+                'h
+                'i))))
 ------------------------------
 #lang racket/base
 (cond

--- a/default-recommendations/conditional-suggestions-test.rkt
+++ b/default-recommendations/conditional-suggestions-test.rkt
@@ -1,0 +1,33 @@
+#lang resyntax/testing/refactoring-test
+
+
+require: resyntax/default-recommendations conditional-suggestions
+
+
+test: "if-else *doesn't* refactor to cond"
+------------------------------
+#lang racket/base
+(if 'cond 'then 'else)
+------------------------------
+
+
+test: "singly-nested if-else *doesn't* refactor to cond"
+------------------------------
+#lang racket/base
+(if 'cond 'then (if 'cond2 'then2 'else))
+------------------------------
+
+
+test: "if-else chain refactors to cond"
+------------------------------
+#lang racket/base
+(if 'a 'b (if 'c 'd (if 'e 'f (if 'g 'h 'i))))
+------------------------------
+#lang racket/base
+(cond
+  ['a 'b]
+  ['c 'd]
+  ['e 'f]
+  ['g 'h]
+  [else 'i])
+------------------------------

--- a/default-recommendations/conditional-suggestions.rkt
+++ b/default-recommendations/conditional-suggestions.rkt
@@ -23,24 +23,24 @@
 
 
 (define-syntax-class nested-if-else
-  #:attributes (branches branches-size)
+  #:attributes ([branch 1] branches-size)
   #:literals (if)
-  (pattern (if cond then (~or* (~var nested nested-if-else) default))
-           #:with branches #`(NEWLINE [cond then]
-                                      #,@(if (attribute default)
-                                             #'(NEWLINE [else default])
-                                             (attribute nested.branches)))
-           #:attr branches-size (if (attribute default)
-                                    2
-                                    (+ 1 (attribute nested.branches-size)))))
+
+  (pattern (if cond then nested:nested-if-else)
+    #:with (branch ...) #'(NEWLINE [cond then] nested.branch ...)
+    #:attr branches-size (+ 1 (attribute nested.branches-size)))
+
+  (pattern (if cond then default)
+    #:with (branch ...) #'(NEWLINE [cond then] NEWLINE [else default])
+    #:attr branches-size 2))
 
 
 (define-refactoring-rule nested-if-to-cond
   #:description "If-else chains can be converted to cond."
   #:literals (cond)
-  [test:nested-if-else
-   #:when (> (attribute test.branches-size) 3)
-   (cond (~@ . test.branches))])
+  [nested:nested-if-else
+   #:when (> (attribute nested.branches-size) 2)
+   (cond nested.branch ...)])
 
 
 (define conditional-suggestions

--- a/default-recommendations/conditional-suggestions.rkt
+++ b/default-recommendations/conditional-suggestions.rkt
@@ -1,0 +1,49 @@
+#lang racket/base
+
+
+(require racket/contract/base)
+
+
+(provide
+ (contract-out
+  [conditional-suggestions refactoring-suite?]))
+
+
+(require (for-syntax racket/base)
+         racket/list
+         rebellion/type/record
+         rebellion/private/static-name
+         resyntax/refactoring-rule
+         resyntax/refactoring-suite
+         resyntax/syntax-replacement
+         syntax/parse)
+
+
+;@------------------------------------------(----------------------------------------------------------
+
+
+(define-syntax-class nested-if-else
+  #:attributes (branches branches-size)
+  #:literals (if)
+  (pattern (if cond then (~or* (~var nested nested-if-else) default))
+           #:with branches #`(NEWLINE [cond then]
+                                      #,@(if (attribute default)
+                                             #'(NEWLINE [else default])
+                                             (attribute nested.branches)))
+           #:attr branches-size (if (attribute default)
+                                    2
+                                    (+ 1 (attribute nested.branches-size)))))
+
+
+(define-refactoring-rule nested-if-to-cond
+  #:description "If-else chains can be converted to cond."
+  #:literals (cond)
+  [test:nested-if-else
+   #:when (> (attribute test.branches-size) 3)
+   (cond (~@ . test.branches))])
+
+
+(define conditional-suggestions
+  (refactoring-suite
+   #:name (name conditional-suggestions)
+   #:rules (list nested-if-to-cond)))

--- a/default-recommendations/miscellaneous-suggestions.rkt
+++ b/default-recommendations/miscellaneous-suggestions.rkt
@@ -52,16 +52,6 @@
      (~@ NEWLINE clause) ...)])
 
 
-(define-refactoring-rule if-else-if-to-cond
-  #:description "These nested ifs can be collapsed into a single cond expression."
-  #:literals (if)
-  [(if condition then-branch (if inner-condition inner-then-branch else-branch))
-   (cond
-     NEWLINE [condition NEWLINE then-branch]
-     NEWLINE [inner-condition NEWLINE inner-then-branch]
-     NEWLINE [else else-branch])])
-
-
 (define-refactoring-rule if-x-else-x-to-and
   #:description "This if expression can be replaced with an equivalent and expression."
   #:literals (if)
@@ -123,6 +113,5 @@
                  if-then-begin-to-cond
                  if-else-begin-to-cond
                  if-else-cond-to-cond
-                 if-else-if-to-cond
                  if-x-else-x-to-and
                  or-cond-to-cond)))


### PR DESCRIPTION
Refactor deeply-nested `(if cond then (if cond then ...))` chains into `(cond)` forms.