### PR TITLE
Implement one-line code block syntax for tests

### DIFF
--- a/default-recommendations/boolean-shortcuts-test.rkt
+++ b/default-recommendations/boolean-shortcuts-test.rkt
@@ -5,40 +5,22 @@ require: resyntax/default-recommendations boolean-shortcuts
 
 
 test: "nested ors can be flattened"
-------------------------------
-#lang racket/base
-(or 1 2 (or 3 4))
-------------------------------
-#lang racket/base
-(or 1 2 3 4)
-------------------------------
+- #lang racket/base (or 1 2 (or 3 4))
+- #lang racket/base (or 1 2 3 4)
 
 
 test: "flat ors can't be flattened"
-------------------------------
-#lang racket/base
-(or 1 2 3)
-------------------------------
+- #lang racket/base (or 1 2 3)
 
 
 test: "multiple nested ors can be flattened at once"
-------------------------------
-#lang racket/base
-(or (or 1 2) (or 3 4) (or 5 6))
-------------------------------
-#lang racket/base
-(or 1 2 3 4 5 6)
-------------------------------
+- #lang racket/base (or (or 1 2) (or 3 4) (or 5 6))
+- #lang racket/base (or 1 2 3 4 5 6)
 
 
 test: "deeply nested ors can be flattened in one pass"
-------------------------------
-#lang racket/base
-(or 1 (or 2 (or 3 (or 4 5 6))))
-------------------------------
-#lang racket/base
-(or 1 2 3 4 5 6)
-------------------------------
+- #lang racket/base (or 1 (or 2 (or 3 (or 4 5 6))))
+- #lang racket/base (or 1 2 3 4 5 6)
 
 
 test: "multiline nested ors can't be flattened"
@@ -50,40 +32,22 @@ test: "multiline nested ors can't be flattened"
 
 
 test: "nested ands can be flattened"
-------------------------------
-#lang racket/base
-(and 1 2 (and 3 4))
-------------------------------
-#lang racket/base
-(and 1 2 3 4)
-------------------------------
+- #lang racket/base (and 1 2 (and 3 4))
+- #lang racket/base (and 1 2 3 4)
 
 
 test: "flat ands can't be flattened"
-------------------------------
-#lang racket/base
-(and 1 2 3)
-------------------------------
+- #lang racket/base (and 1 2 3)
 
 
 test: "multiple nested ands can be flattened at once"
-------------------------------
-#lang racket/base
-(and (and 1 2) (and 3 4) (and 5 6))
-------------------------------
-#lang racket/base
-(and 1 2 3 4 5 6)
-------------------------------
+- #lang racket/base (and (and 1 2) (and 3 4) (and 5 6))
+- #lang racket/base (and 1 2 3 4 5 6)
 
 
 test: "deeply nested ands can be flattened in one pass"
-------------------------------
-#lang racket/base
-(and 1 (and 2 (and 3 (and 4 5 6))))
-------------------------------
-#lang racket/base
-(and 1 2 3 4 5 6)
-------------------------------
+- #lang racket/base (and 1 (and 2 (and 3 (and 4 5 6))))
+- #lang racket/base (and 1 2 3 4 5 6)
 
 
 test: "multiline nested ands can't be flattened"
@@ -95,40 +59,20 @@ test: "multiline nested ands can't be flattened"
 
 
 test: "nested ors interspersed with ands can be flattened"
-------------------------------
-#lang racket/base
-(or (or 1 2) (and 3 4) (or 5 6))
-------------------------------
-#lang racket/base
-(or 1 2 (and 3 4) 5 6)
-------------------------------
+- #lang racket/base (or (or 1 2) (and 3 4) (or 5 6))
+- #lang racket/base (or 1 2 (and 3 4) 5 6)
 
 
 test: "nested ands interspersed with ors can be flattened"
-------------------------------
-#lang racket/base
-(and (and 1 2) (or 3 4) (and 5 6))
-------------------------------
-#lang racket/base
-(and 1 2 (or 3 4) 5 6)
-------------------------------
+- #lang racket/base (and (and 1 2) (or 3 4) (and 5 6))
+- #lang racket/base (and 1 2 (or 3 4) 5 6)
 
 
 test: "de morgan's law can refactor ands to ors"
-------------------------------
-#lang racket/base
-(and (not 1) (not 2) (not 3))
-------------------------------
-#lang racket/base
-(not (or 1 2 3))
-------------------------------
+- #lang racket/base (and (not 1) (not 2) (not 3))
+- #lang racket/base (not (or 1 2 3))
 
 
 test: "de morgan's law can refactor ors to ands"
-------------------------------
-#lang racket/base
-(or (not 1) (not 2) (not 3))
-------------------------------
-#lang racket/base
-(not (and 1 2 3))
-------------------------------
+- #lang racket/base (or (not 1) (not 2) (not 3))
+- #lang racket/base (not (and 1 2 3))

--- a/default-recommendations/comparison-shortcuts-test.rkt
+++ b/default-recommendations/comparison-shortcuts-test.rkt
@@ -11,6 +11,7 @@ test: "(> (- x y) 0) refactorable to direct comparison"
 (define y 2)
 (> (- x y) 0)
 ------------------------------
+------------------------------
 #lang racket/base
 (define x 1)
 (define y 2)
@@ -24,6 +25,7 @@ test: "(< (- x y) 0) refactorable to direct comparison"
 (define x 1)
 (define y 2)
 (< (- x y) 0)
+------------------------------
 ------------------------------
 #lang racket/base
 (define x 1)
@@ -39,6 +41,7 @@ test: "(>= (- x y) 0) refactorable to direct comparison"
 (define y 2)
 (>= (- x y) 0)
 ------------------------------
+------------------------------
 #lang racket/base
 (define x 1)
 (define y 2)
@@ -52,6 +55,7 @@ test: "(<= (- x y) 0) refactorable to direct comparison"
 (define x 1)
 (define y 2)
 (<= (- x y) 0)
+------------------------------
 ------------------------------
 #lang racket/base
 (define x 1)
@@ -67,6 +71,7 @@ test: "(> 0 (- x y)) refactorable to direct comparison"
 (define y 2)
 (> 0 (- x y))
 ------------------------------
+------------------------------
 #lang racket/base
 (define x 1)
 (define y 2)
@@ -80,6 +85,7 @@ test: "(< 0 (- x y)) refactorable to direct comparison"
 (define x 1)
 (define y 2)
 (< 0 (- x y))
+------------------------------
 ------------------------------
 #lang racket/base
 (define x 1)
@@ -95,6 +101,7 @@ test: "(>= 0 (- x y)) refactorable to direct comparison"
 (define y 2)
 (>= 0 (- x y))
 ------------------------------
+------------------------------
 #lang racket/base
 (define x 1)
 (define y 2)
@@ -108,6 +115,7 @@ test: "(<= 0 (- x y)) refactorable to direct comparison"
 (define x 1)
 (define y 2)
 (<= 0 (- x y))
+------------------------------
 ------------------------------
 #lang racket/base
 (define x 1)

--- a/default-recommendations/conditional-shortcuts-test.rkt
+++ b/default-recommendations/conditional-shortcuts-test.rkt
@@ -5,16 +5,14 @@ require: resyntax/default-recommendations conditional-shortcuts
 
 
 test: "if without nested ifs not refactorable"
-------------------------------
-#lang racket/base
-(if 'cond 'then 'else)
-------------------------------
+- #lang racket/base (if 'cond 'then 'else)
 
 
 test: "singly-nested ifs refactorable to cond"
 ------------------------------
 #lang racket/base
 (if 'cond 'then (if 'cond2 'then2 'else))
+------------------------------
 ------------------------------
 #lang racket/base
 (cond
@@ -28,6 +26,7 @@ test: "one-line nested ifs refactorable to cond"
 ------------------------------
 #lang racket/base
 (if 'a 'b (if 'c 'd (if 'e 'f (if 'g 'h 'i))))
+------------------------------
 ------------------------------
 #lang racket/base
 (cond
@@ -52,6 +51,7 @@ test: "multi-line nested ifs refactorable to cond"
                 'h
                 'i))))
 ------------------------------
+------------------------------
 #lang racket/base
 (cond
   ['a 'b]
@@ -63,13 +63,8 @@ test: "multi-line nested ifs refactorable to cond"
 
 
 test: "if else false can be refactored to an and expression"
-------------------------------
-#lang racket/base
-(if 'a (println "true branch") #f)
-------------------------------
-#lang racket/base
-(and 'a (println "true branch"))
-------------------------------
+- #lang racket/base (if 'a (println "true branch") #f)
+- #lang racket/base (and 'a (println "true branch"))
 
 
 test: "multi-line if else false can be refactored to a multi-line and expression"
@@ -78,6 +73,7 @@ test: "multi-line if else false can be refactored to a multi-line and expression
 (if 'a
     (println "true branch")
     #f)
+------------------------------
 ------------------------------
 #lang racket/base
 (and 'a
@@ -90,6 +86,7 @@ test: "if x else x can be refactored to an and expression"
 #lang racket/base
 (define x 'a)
 (if x (println "true branch") x)
+------------------------------
 ------------------------------
 #lang racket/base
 (define x 'a)
@@ -104,6 +101,7 @@ test: "multi-line if x else x can be refactored to a multi-line and expression"
 (if x
     (println "true branch")
     x)
+------------------------------
 ------------------------------
 #lang racket/base
 (define x 'a)

--- a/default-recommendations/contract-shortcuts-test.rkt
+++ b/default-recommendations/contract-shortcuts-test.rkt
@@ -10,6 +10,7 @@ test: "nested or/c contracts can be flattened"
 (require racket/contract/base)
 (void (or/c 1 2 (or/c 3 4)))
 ------------------------------
+------------------------------
 #lang racket/base
 (require racket/contract/base)
 (void (or/c 1 2 3 4))
@@ -30,6 +31,7 @@ test: "multiple nested or/c contracts can be flattened at once"
 (require racket/contract/base)
 (void (or/c (or/c 1 2) (or/c 3 4) (or/c 5 6)))
 ------------------------------
+------------------------------
 #lang racket/base
 (require racket/contract/base)
 (void (or/c 1 2 3 4 5 6))
@@ -41,6 +43,7 @@ test: "deeply nested or/c contracts can be flattened in one pass"
 #lang racket/base
 (require racket/contract/base)
 (void (or/c 1 (or/c 2 (or/c 3 (or/c 4 5 6)))))
+------------------------------
 ------------------------------
 #lang racket/base
 (require racket/contract/base)
@@ -64,6 +67,7 @@ test: "nested and/c contracts can be flattened"
 (require racket/contract/base)
 (void (and/c 1 2 (and/c 3 4)))
 ------------------------------
+------------------------------
 #lang racket/base
 (require racket/contract/base)
 (void (and/c 1 2 3 4))
@@ -84,6 +88,7 @@ test: "multiple nested and/c contracts can be flattened at once"
 (require racket/contract/base)
 (void (and/c (and/c 1 2) (and/c 3 4) (and/c 5 6)))
 ------------------------------
+------------------------------
 #lang racket/base
 (require racket/contract/base)
 (void (and/c 1 2 3 4 5 6))
@@ -95,6 +100,7 @@ test: "deeply nested and/c contracts can be flattened in one pass"
 #lang racket/base
 (require racket/contract/base)
 (void (and/c 1 (and/c 2 (and/c 3 (and/c 4 5 6)))))
+------------------------------
 ------------------------------
 #lang racket/base
 (require racket/contract/base)
@@ -118,6 +124,7 @@ test: "nested or/c contracts interspersed with and/c contracts can be flattened"
 (require racket/contract/base)
 (void (or/c (or/c 1 2) (and/c 3 4) (or/c 5 6)))
 ------------------------------
+------------------------------
 #lang racket/base
 (require racket/contract/base)
 (void (or/c 1 2 (and/c 3 4) 5 6))
@@ -130,6 +137,7 @@ test: "nested and/c contracts interspersed with or/c contracts can be flattened"
 (require racket/contract/base)
 (void (and/c (and/c 1 2) (or/c 3 4) (and/c 5 6)))
 ------------------------------
+------------------------------
 #lang racket/base
 (require racket/contract/base)
 (void (and/c 1 2 (or/c 3 4) 5 6))
@@ -141,6 +149,7 @@ test: "contracts equivalent to predicate/c can be refactored to predicate/c"
 #lang racket/base
 (require racket/contract/base)
 (void (-> any/c boolean?))
+------------------------------
 ------------------------------
 #lang racket/base
 (require racket/contract/base)

--- a/default-recommendations/for-loop-shortcuts-test.rkt
+++ b/default-recommendations/for-loop-shortcuts-test.rkt
@@ -21,6 +21,7 @@ test: "for-each with long single-form body to for"
    (displayln a-very-very-very-long-variable-name-thats-so-very-long))
  some-list)
 ------------------------------
+------------------------------
 #lang racket/base
 (define some-list (list 1 2 3))
 (for ([a-very-very-very-long-variable-name-thats-so-very-long (in-list some-list)])
@@ -38,6 +39,7 @@ test: "for-each with multiple body forms to for"
    (displayln x))
  some-list)
 ------------------------------
+------------------------------
 #lang racket/base
 (define some-list (list 1 2 3))
 (for ([x (in-list some-list)])
@@ -51,6 +53,7 @@ test: "for-each with let expression to for with definitions"
 #lang racket/base
 (define some-list (list 1 2 3))
 (for-each (λ (x) (let ([y 1]) (displayln x))) some-list)
+------------------------------
 ------------------------------
 #lang racket/base
 (define some-list (list 1 2 3))
@@ -70,6 +73,7 @@ test: "for-each range to for"
    (displayln x))
  (range 0 10))
 ------------------------------
+------------------------------
 #lang racket/base
 (require racket/list)
 (for ([x (in-range 0 10)])
@@ -87,6 +91,7 @@ test: "for-each string->list to for in-string"
    (displayln x))
  (string->list "hello"))
 ------------------------------
+------------------------------
 #lang racket/base
 (for ([x (in-string "hello")])
   (displayln x)
@@ -103,6 +108,7 @@ test: "for-each bytes->list to for in-bytes"
    (displayln x))
  (bytes->list #"hello"))
 ------------------------------
+------------------------------
 #lang racket/base
 (for ([x (in-bytes #"hello")])
   (displayln x)
@@ -116,6 +122,7 @@ test: "for/fold building hash to for/hash"
 (for/fold ([h (hash)]) ([x (in-range 0 10)])
   (hash-set h x 'foo))
 ------------------------------
+------------------------------
 #lang racket/base
 (for/hash ([x (in-range 0 10)])
   (values x 'foo))
@@ -127,6 +134,7 @@ test: "for*/fold building hash to for*/hash"
 #lang racket/base
 (for*/fold ([h (hash)]) ([x (in-range 0 10)])
   (hash-set h x 'foo))
+------------------------------
 ------------------------------
 #lang racket/base
 (for*/hash ([x (in-range 0 10)])

--- a/default-recommendations/function-definition-shortcuts-test.rkt
+++ b/default-recommendations/function-definition-shortcuts-test.rkt
@@ -11,6 +11,7 @@ test: "lambda variable definition to function definition"
   (λ (a b c)
     1))
 ------------------------------
+------------------------------
 #lang racket/base
 (define (f a b c)
   1)
@@ -24,6 +25,7 @@ test: "lambda variable definition with no arguments to function definition"
   (λ ()
     1))
 ------------------------------
+------------------------------
 #lang racket/base
 (define (f)
   1)
@@ -34,6 +36,7 @@ test: "one-line lambda variable definition to one-line function definition"
 ------------------------------
 #lang racket/base
 (define f (λ (a b c) 1))
+------------------------------
 ------------------------------
 #lang racket/base
 (define (f a b c) 1)
@@ -46,6 +49,7 @@ test: "lambda variable definition with only rest argument to function definition
 (define f
   (λ xs
     1))
+------------------------------
 ------------------------------
 #lang racket/base
 (define (f . xs)
@@ -60,6 +64,7 @@ test: "lambda variable definition with rest argument to function definition"
   (λ (a b c . xs)
     1))
 ------------------------------
+------------------------------
 #lang racket/base
 (define (f a b c . xs)
   1)
@@ -72,6 +77,7 @@ test: "lambda function definition to function definition"
 (define (f a b c)
   (λ (x y z)
     1))
+------------------------------
 ------------------------------
 #lang racket/base
 (define ((f a b c) x y z)
@@ -98,6 +104,7 @@ test: "lambda variable definition with long header to function definition with p
       c)
     1))
 ------------------------------
+------------------------------
 #lang racket/base
 (define (f a
            b
@@ -116,6 +123,7 @@ test: "lambda variable definition with commented body to definition with preserv
     ;; comment before last body form
     1))
 ------------------------------
+------------------------------
 #lang racket/base
 (define (f a)
   ;; comment before all body forms
@@ -133,6 +141,7 @@ test: "nested lambda variable definition to function definition"
     (λ (b)
       1)))
 ------------------------------
+------------------------------
 #lang racket/base
 (define ((f a) b)
   1)
@@ -146,6 +155,7 @@ test: "nested lambda function definition to function definition"
   (λ (b)
     (λ (c)
       1)))
+------------------------------
 ------------------------------
 #lang racket/base
 (define (((f a) b) c)
@@ -199,6 +209,7 @@ test: "case-lambda with default arg"
     [(x)
      1]))
 ------------------------------
+------------------------------
 #lang racket/base
 (define (f [x 1])
   1)
@@ -214,6 +225,7 @@ test: "case-lambda with default arg and required args"
      (f a b c 1)]
     [(a b c x)
      1]))
+------------------------------
 ------------------------------
 #lang racket/base
 (define (f a b c [x 1])
@@ -244,6 +256,7 @@ test: "case-lambda with default arg and multiple body forms"
      (void)
      1]))
 ------------------------------
+------------------------------
 #lang racket/base
 (define (f [x 1])
   (void)
@@ -262,6 +275,7 @@ test: "case-lambda with default arg and body form with interior comments"
      (begin
        ;;comment
        1)]))
+------------------------------
 ------------------------------
 #lang racket/base
 (define (f [x 1])

--- a/default-recommendations/hash-shortcuts-test.rkt
+++ b/default-recommendations/hash-shortcuts-test.rkt
@@ -14,6 +14,7 @@ test: "hash-ref with hash-set! lambda can be simplified to hash-ref!"
                 (hash-set! h k v)
                 v))
 ------------------------------
+------------------------------
 #lang racket/base
 (define h (make-hash))
 (define k 'a)

--- a/default-recommendations/legacy-struct-migrations-test.rkt
+++ b/default-recommendations/legacy-struct-migrations-test.rkt
@@ -8,6 +8,7 @@ test: "define-struct without options"
 #lang racket/base
 (define-struct point (x y))
 ----------------------------------------
+----------------------------------------
 #lang racket/base
 (struct point (x y)
   #:extra-constructor-name make-point)
@@ -20,6 +21,7 @@ test: "define-struct with simple options"
 (define-struct point (x y)
   #:transparent
   #:mutable)
+----------------------------------------
 ----------------------------------------
 #lang racket/base
 (struct point (x y)
@@ -34,6 +36,7 @@ test: "one-line define-struct with simple options"
 #lang racket/base
 (define-struct point (x y) #:transparent #:mutable)
 ----------------------------------------
+----------------------------------------
 #lang racket/base
 (struct point (x y) #:transparent #:mutable
   #:extra-constructor-name make-point)
@@ -45,6 +48,7 @@ test: "define-struct with supertype"
 #lang racket/base
 (struct point ())
 (define-struct (2d-point point) (x y))
+----------------------------------------
 ----------------------------------------
 #lang racket/base
 (struct point ())
@@ -60,6 +64,7 @@ test: "define-struct with multi-form single-line options"
   #:guard (λ (x y _) (values x y))
   #:property prop:custom-print-quotable 'never
   #:inspector #false)
+----------------------------------------
 ----------------------------------------
 #lang racket/base
 (struct point (x y)
@@ -77,6 +82,7 @@ test: "define-struct with multi-line options"
   #:property prop:custom-write
   (λ (this out mode)
     (write-string "#<point>" out)))
+----------------------------------------
 ----------------------------------------
 #lang racket/base
 (struct point (x y)
@@ -98,6 +104,7 @@ test: "define-struct with options with separating whitespace"
 
   #:guard (λ (x y _) (values x y)))
 ----------------------------------------
+----------------------------------------
 #lang racket/base
 (struct point (x y)
 
@@ -116,6 +123,7 @@ test: "define-struct with field comments"
 (define-struct point (x ;; The X coordinate of the point
                       y ;; The Y coordinate of the point
                       ))
+----------------------------------------
 ----------------------------------------
 #lang racket/base
 (struct point (x ;; The X coordinate of the point
@@ -137,6 +145,7 @@ test: "define-struct with comments between options"
 
   ;; Field guard
   #:guard (λ (x y _) (values x y)))
+----------------------------------------
 ----------------------------------------
 #lang racket/base
 (struct point (x y)

--- a/default-recommendations/let-binding-suggestions-comment-test.rkt
+++ b/default-recommendations/let-binding-suggestions-comment-test.rkt
@@ -13,6 +13,7 @@ test: "let binding with commented right-hand-side expression"
          1])
     1))
 ------------------------------
+------------------------------
 #lang racket/base
 (define (f)
   (define x

--- a/default-recommendations/let-binding-suggestions-function-shortcuts-test.rkt
+++ b/default-recommendations/let-binding-suggestions-function-shortcuts-test.rkt
@@ -11,6 +11,7 @@ test: "let binding to lambda"
   (let ([g (λ (x y) 1)])
     1))
 ------------------------------
+------------------------------
 #lang racket/base
 (define (f)
   (define (g x y)
@@ -25,6 +26,7 @@ test: "let binding to lambda with keyword args"
 (define (f)
   (let ([g (λ (#:x x #:y y) 1)])
     1))
+------------------------------
 ------------------------------
 #lang racket/base
 (define (f)
@@ -41,6 +43,7 @@ test: "let binding to lambda with optional args"
   (let ([g (λ ([x 1] [y 1]) 1)])
     1))
 ------------------------------
+------------------------------
 #lang racket/base
 (define (f)
   (define (g [x 1] [y 1])
@@ -56,6 +59,7 @@ test: "let binding to lambda with only rest args"
   (let ([g (λ xs 1)])
     1))
 ------------------------------
+------------------------------
 #lang racket/base
 (define (f)
   (define (g . xs)
@@ -70,6 +74,7 @@ test: "let binding to lambda with positional and rest args"
 (define (f)
   (let ([g (λ (x y . zs) 1)])
     1))
+------------------------------
 ------------------------------
 #lang racket/base
 (define (f)

--- a/default-recommendations/let-binding-suggestions-test.rkt
+++ b/default-recommendations/let-binding-suggestions-test.rkt
@@ -11,6 +11,7 @@ test: "single let binding"
   (let ([x 1])
     1))
 ------------------------------
+------------------------------
 #lang racket/base
 (define (f)
   (define x 1)
@@ -24,6 +25,7 @@ test: "single let* binding"
 (define (f)
   (let* ([x 1])
     1))
+------------------------------
 ------------------------------
 #lang racket/base
 (define (f)
@@ -39,6 +41,7 @@ test: "single-clause let-values binding"
   (let-values ([(x y) (values 1 1)])
     1))
 ------------------------------
+------------------------------
 #lang racket/base
 (define (f)
   (define-values (x y) (values 1 1))
@@ -52,6 +55,7 @@ test: "single-clause let*-values binding"
 (define (f)
   (let*-values ([(x y) (values 1 1)])
     1))
+------------------------------
 ------------------------------
 #lang racket/base
 (define (f)
@@ -67,6 +71,7 @@ test: "multiple let bindings"
   (let ([x 1]
         [y 1])
     1))
+------------------------------
 ------------------------------
 #lang racket/base
 (define (f)
@@ -84,6 +89,7 @@ test: "multiple let* bindings"
          [y 1])
     1))
 ------------------------------
+------------------------------
 #lang racket/base
 (define (f)
   (define x 1)
@@ -100,6 +106,7 @@ test: "multiple let-values bindings"
                [(a b) (values 1 1)])
     1))
 ------------------------------
+------------------------------
 #lang racket/base
 (define (f)
   (define-values (x y) (values 1 1))
@@ -115,6 +122,7 @@ test: "multiple let*-values bindings"
   (let*-values ([(x y) (values 1 1)]
                 [(a b) (values 1 1)])
     1))
+------------------------------
 ------------------------------
 #lang racket/base
 (define (f)
@@ -167,6 +175,7 @@ test: "let forms inside lambdas"
   (let ([x 1])
     1))
 ------------------------------
+------------------------------
 #lang racket/base
 (λ ()
   (define x 1)
@@ -181,6 +190,7 @@ test: "let forms inside unrefactorable let forms"
 (let ([a a])
   (let ([x 1])
     1))
+------------------------------
 ------------------------------
 #lang racket/base
 (define a 1)
@@ -197,6 +207,7 @@ test: "let forms inside let loops"
   (let ([x 1])
     1))
 ------------------------------
+------------------------------
 #lang racket/base
 (let loop ()
   (define x 1)
@@ -212,6 +223,7 @@ test: "let forms inside unrefactorable let* forms"
        [a a])
   (let ([x 1])
     1))
+------------------------------
 ------------------------------
 #lang racket/base
 (define a 1)
@@ -230,6 +242,7 @@ test: "let forms inside unrefactorable let-values forms"
   (let ([x 1])
     1))
 ------------------------------
+------------------------------
 #lang racket/base
 (define a 1)
 (let-values ([(a b) (values a 1)])
@@ -246,6 +259,7 @@ test: "let forms inside unrefactorable let*-values forms"
   (let ([x 1])
     1))
 ------------------------------
+------------------------------
 #lang racket/base
 (define a 1)
 (let*-values ([(a b) (values a 1)])
@@ -261,6 +275,7 @@ test: "let forms inside when forms"
   (let ([x 1])
     1))
 ------------------------------
+------------------------------
 #lang racket/base
 (when #true
   (define x 1)
@@ -275,6 +290,7 @@ test: "let forms inside unless forms"
   (let ([x 1])
     1))
 ------------------------------
+------------------------------
 #lang racket/base
 (unless #false
   (define x 1)
@@ -288,6 +304,7 @@ test: "let forms inside with-handlers forms"
 (with-handlers ([exn:fail? void])
   (let ([x 1])
     1))
+------------------------------
 ------------------------------
 #lang racket/base
 (with-handlers ([exn:fail? void])
@@ -304,6 +321,7 @@ test: "let forms inside parameterize forms"
   (let ([x 1])
     1))
 ------------------------------
+------------------------------
 #lang racket/base
 (define p (make-parameter #false))
 (parameterize ([p #true])
@@ -319,6 +337,7 @@ test: "let forms inside for loop bodies"
   (let ([x 1])
     (void)))
 ------------------------------
+------------------------------
 #lang racket/base
 (for ([i (in-range 0 10)])
   (define x 1)
@@ -331,6 +350,7 @@ test: "named lets which don't refer to the name are refactorable to unnamed lets
 #lang racket/base
 (let loop ([x 1])
   x)
+------------------------------
 ------------------------------
 #lang racket/base
 (let ([x 1])

--- a/default-recommendations/list-shortcuts-test.rkt
+++ b/default-recommendations/list-shortcuts-test.rkt
@@ -5,10 +5,7 @@ require: resyntax/default-recommendations list-shortcuts
 
 
 test: "car reverse of list not refactorable to last of list, due to imports (see issue #11)"
-------------------------------
-#lang racket/base
-(car (reverse (list 1 2 3)))
-------------------------------
+- #lang racket/base (car (reverse (list 1 2 3)))
 
 
 test: "first reverse of list refactorable to last of list"
@@ -17,6 +14,7 @@ test: "first reverse of list refactorable to last of list"
 (require racket/list)
 (first (reverse (list 1 2 3)))
 ------------------------------
+------------------------------
 #lang racket/base
 (require racket/list)
 (last (list 1 2 3))
@@ -24,103 +22,53 @@ test: "first reverse of list refactorable to last of list"
 
 
 test: "list eq? to quoted empty list refactorable to null? check"
-------------------------------
-#lang racket/base
-(eq? (list 1 2 3) '())
-------------------------------
-#lang racket/base
-(null? (list 1 2 3))
-------------------------------
+- #lang racket/base (eq? (list 1 2 3) '())
+- #lang racket/base (null? (list 1 2 3))
 
 
 test: "list eqv? to quoted empty list refactorable to null? check"
-------------------------------
-#lang racket/base
-(eqv? (list 1 2 3) '())
-------------------------------
-#lang racket/base
-(null? (list 1 2 3))
-------------------------------
+- #lang racket/base (eqv? (list 1 2 3) '())
+- #lang racket/base (null? (list 1 2 3))
 
 
 test: "list equal? to quoted empty list refactorable to null? check"
-------------------------------
-#lang racket/base
-(equal? (list 1 2 3) '())
-------------------------------
-#lang racket/base
-(null? (list 1 2 3))
-------------------------------
+- #lang racket/base (equal? (list 1 2 3) '())
+- #lang racket/base (null? (list 1 2 3))
 
 
 test: "list eq? to (list) refactorable to null? check"
-------------------------------
-#lang racket/base
-(eq? (list 1 2 3) (list))
-------------------------------
-#lang racket/base
-(null? (list 1 2 3))
-------------------------------
+- #lang racket/base (eq? (list 1 2 3) (list))
+- #lang racket/base (null? (list 1 2 3))
 
 
 test: "list eqv? to (list) refactorable to null? check"
-------------------------------
-#lang racket/base
-(eqv? (list 1 2 3) (list))
-------------------------------
-#lang racket/base
-(null? (list 1 2 3))
-------------------------------
+- #lang racket/base (eqv? (list 1 2 3) (list))
+- #lang racket/base (null? (list 1 2 3))
 
 
 test: "list equal? to (list) refactorable to null? check"
-------------------------------
-#lang racket/base
-(equal? (list 1 2 3) (list))
-------------------------------
-#lang racket/base
-(null? (list 1 2 3))
-------------------------------
+- #lang racket/base (equal? (list 1 2 3) (list))
+- #lang racket/base (null? (list 1 2 3))
 
 
 test: "list eq? to null refactorable to null? check"
-------------------------------
-#lang racket/base
-(eq? (list 1 2 3) null)
-------------------------------
-#lang racket/base
-(null? (list 1 2 3))
-------------------------------
+- #lang racket/base (eq? (list 1 2 3) null)
+- #lang racket/base (null? (list 1 2 3))
 
 
 test: "list eqv? to null refactorable to null? check"
-------------------------------
-#lang racket/base
-(eqv? (list 1 2 3) null)
-------------------------------
-#lang racket/base
-(null? (list 1 2 3))
-------------------------------
+- #lang racket/base (eqv? (list 1 2 3) null)
+- #lang racket/base (null? (list 1 2 3))
 
 
 test: "list equal? to null refactorable to null? check"
-------------------------------
-#lang racket/base
-(equal? (list 1 2 3) null)
-------------------------------
-#lang racket/base
-(null? (list 1 2 3))
-------------------------------
+- #lang racket/base (equal? (list 1 2 3) null)
+- #lang racket/base (null? (list 1 2 3))
 
 
 test: "(list) refactorable to '() check"
-------------------------------
-#lang racket/base
-(list)
-------------------------------
-#lang racket/base
-'()
-------------------------------
+- #lang racket/base (list)
+- #lang racket/base '()
 
 
 test: "(append* (map ...)) refactorable to single-pass append-map"
@@ -129,6 +77,7 @@ test: "(append* (map ...)) refactorable to single-pass append-map"
 (require racket/list)
 (define (f x) (list x x x))
 (append* (map f (list 1 2 3)))
+------------------------------
 ------------------------------
 #lang racket/base
 (require racket/list)
@@ -142,6 +91,7 @@ test: "sort by comparator using key refactorable to sort by key"
 #lang racket/base
 (define (f x) 42)
 (sort (list 1 2 3) (λ (a b) (< (f a) (f b))))
+------------------------------
 ------------------------------
 #lang racket/base
 (define (f x) 42)

--- a/testing/refactoring-test-parser.rkt
+++ b/testing/refactoring-test-parser.rkt
@@ -2,4 +2,4 @@
 
 refactoring-test: refactoring-test-import* refactoring-test-case*
 refactoring-test-import: /REQUIRE-KEYWORD IDENTIFIER IDENTIFIER
-refactoring-test-case: /TEST-KEYWORD STRING-LITERAL /SEPARATOR-LINE (LANG-BLOCK /SEPARATOR-LINE){1,2}
+refactoring-test-case: /TEST-KEYWORD STRING-LITERAL CODE-BLOCK{1,2}

--- a/testing/refactoring-test-tokenizer.rkt
+++ b/testing/refactoring-test-tokenizer.rkt
@@ -9,7 +9,16 @@
   [make-refactoring-test-tokenizer (-> input-port? (-> (or/c position-token? eof-object?)))]))
 
 
-(require br-parser-tools/lex)
+(require br-parser-tools/lex
+         racket/block
+         racket/list
+         racket/string)
+
+
+(module+ test
+  (require (submod "..")
+           brag/support
+           rackunit))
 
 
 ;@----------------------------------------------------------------------------------------------------
@@ -19,10 +28,15 @@
   (concatenation (repetition 3 +inf.0 #\-)))
 
 
-(define-lex-abbrev refactoring-test-lang-block
-  (concatenation
-   "#lang "
-   (complement (concatenation any-string #\newline "-" any-string))))
+(define-lex-abbrev refactoring-test-code-block
+  (concatenation refactoring-test-separator-line
+                 (complement (concatenation any-string #\newline "-" any-string))
+                 #\newline
+                 refactoring-test-separator-line))
+
+
+(define-lex-abbrev refactoring-test-code-line
+  (concatenation #\- #\space (complement (concatenation any-string #\newline any-string)) #\newline))
 
 
 (define-lex-abbrev refactoring-test-string-literal
@@ -33,8 +47,13 @@
   (repetition 1 +inf.0 (union alphabetic symbolic numeric (char-set "-/"))))
 
 
-(define-tokens refactoring-test-tokens (IDENTIFIER STRING-LITERAL LANG-BLOCK))
+(define-tokens refactoring-test-tokens (IDENTIFIER STRING-LITERAL CODE-BLOCK))
 (define-empty-tokens empty-refactoring-test-tokens (REQUIRE-KEYWORD TEST-KEYWORD SEPARATOR-LINE))
+
+
+(define (string-lines str)
+  (for/list ([line (in-lines (open-input-string str))])
+    (string->immutable-string line)))
 
 
 (define refactoring-test-lexer
@@ -43,7 +62,12 @@
    ["require:" (token-REQUIRE-KEYWORD)]
    ["test:" (token-TEST-KEYWORD)]
    [refactoring-test-separator-line (token-SEPARATOR-LINE)]
-   [refactoring-test-lang-block (token-LANG-BLOCK (string->immutable-string lexeme))]
+   [refactoring-test-code-line (token-CODE-BLOCK (string->immutable-string (substring lexeme 2)))]
+   [refactoring-test-code-block
+    (block
+     (define lines (drop-right (drop (string-lines lexeme) 1) 1))
+     (token-CODE-BLOCK
+      (if (empty? lines) "" (string->immutable-string (string-join lines "\n" #:after-last "\n")))))]
    [refactoring-test-string-literal
     (token-STRING-LITERAL
      (string->immutable-string (substring lexeme 1 (sub1 (string-length lexeme)))))]
@@ -52,3 +76,51 @@
 
 (define ((make-refactoring-test-tokenizer port))
   (refactoring-test-lexer port))
+
+
+(module+ test
+  (test-case "make-refactoring-test-tokenizer"
+
+    (test-case "code blocks"
+      (define input (open-input-string "---\n#lang racket/base\n(void)\n---"))
+      (port-count-lines! input)
+      (define tokenizer (make-refactoring-test-tokenizer input))
+      (define expected-token
+        (position-token
+         (token-CODE-BLOCK "#lang racket/base\n(void)\n")
+         (position 1 1 0)
+         (position 33 4 3)))
+      (check-equal? (tokenizer) expected-token))
+
+    (test-case "empty code blocks"
+      (define input (open-input-string "---\n---"))
+      (port-count-lines! input)
+      (define tokenizer (make-refactoring-test-tokenizer input))
+      (define expected-token
+        (position-token
+         (token-CODE-BLOCK "")
+         (position 1 1 0)
+         (position 8 2 3)))
+      (check-equal? (tokenizer) expected-token))
+
+    (test-case "code lines"
+      (define input (open-input-string "- #lang racket/base (void)\n"))
+      (port-count-lines! input)
+      (define tokenizer (make-refactoring-test-tokenizer input))
+      (define expected-token
+        (position-token
+         (token-CODE-BLOCK "#lang racket/base (void)\n")
+         (position 1 1 0)
+         (position 28 2 0)))
+      (check-equal? (tokenizer) expected-token))
+
+    (test-case "multiple code lines"
+      (define input (open-input-string "- #lang racket/base (f)\n- #lang racket/base (g)\n"))
+      (port-count-lines! input)
+      (define tokenizer (make-refactoring-test-tokenizer input))
+      (define expected-token
+        (position-token
+         (token-CODE-BLOCK "#lang racket/base (f)\n")
+         (position 1 1 0)
+         (position 25 2 0)))
+      (check-equal? (tokenizer) expected-token))))


### PR DESCRIPTION
Closes #72. Most tests can't use it yet because #70 isn't implemented, but a few can. This also required adjusting the reader to read entire code blocks as a single token, instead of tokenizing the separator lines and lang blocks separately. This means an extra separator line is needed between two code blocks, since they need their own separate start and end separator lines and can't share a separator line boundary.