### PR TITLE
Add a shortcut for using call-with-values instead of let-values

### DIFF
--- a/default-recommendations/let-binding-suggestions-test.rkt
+++ b/default-recommendations/let-binding-suggestions-test.rkt
@@ -325,3 +325,12 @@ test: "named lets which do refer to the name aren't refactorable to unnamed lets
       x
       (loop (sub1 x))))
 ------------------------------
+
+
+test: "let-values expressions with an immediate call are refactorable to call-with-values"
+- (let-values ([(x y z) (values 1 2 3)]) (list x y z))
+- (call-with-values (λ () (values 1 2 3)) list)
+
+
+test: "let-values expressions with an immediate call with different order aren't refactorable"
+- (let-values ([(x y z) (values 1 2 3)]) (list z y x))

--- a/default-recommendations/let-binding-suggestions.rkt
+++ b/default-recommendations/let-binding-suggestions.rkt
@@ -25,6 +25,7 @@
          rebellion/private/static-name
          resyntax/default-recommendations/private/lambda-by-any-name
          resyntax/default-recommendations/private/let-binding
+         resyntax/default-recommendations/private/syntax-equivalence
          resyntax/default-recommendations/private/syntax-identifier-sets
          resyntax/refactoring-rule
          resyntax/refactoring-suite
@@ -173,7 +174,17 @@
    (let (ORIGINAL-SPLICE header body ...))])
 
 
+(define-refactoring-rule let-values-then-call-to-call-with-values
+  #:description
+  "This let-values expression can be replaced with a simpler, equivalent call-with-values expression."
+  #:literals (let-values)
+  [(let-values ([(bound-id:id ...+) expr])
+     (receiver:id arg-id:id ...+))
+   #:when (syntax-free-identifier=? #'(bound-id ...) #'(arg-id ...))
+   (call-with-values (λ () expr) receiver)])
+
+
 (define let-binding-suggestions
   (refactoring-suite
    #:name (name let-binding-suggestions)
-   #:rules (list let-to-define named-let-to-plain-let)))
+   #:rules (list let-to-define let-values-then-call-to-call-with-values named-let-to-plain-let)))

--- a/default-recommendations/private/syntax-equivalence.rkt
+++ b/default-recommendations/private/syntax-equivalence.rkt
@@ -1,0 +1,66 @@
+#lang racket/base
+
+
+(require racket/contract/base)
+
+
+(provide
+ (contract-out
+  [syntax-free-identifier=? (-> syntax? syntax? boolean?)]))
+
+
+(require racket/list
+         racket/match
+         rebellion/private/guarded-block)
+
+
+(module+ test
+  (require (submod "..")
+           rackunit))
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(define/guard (syntax-free-identifier=? stx other-stx)
+  (define datum (syntax-e stx))
+  (define other-datum (syntax-e other-stx))
+  (match datum
+    [(? symbol?) (and (symbol? other-datum) (free-identifier=? stx other-stx))]
+    [(? number? boolean? string?) (equal? datum other-datum)]
+    [(? list?) (and (list? other-datum) (syntax-pair-free-identifier=? datum other-datum))]
+    [(? box?) (and (box? other-datum) (syntax-free-identifier=? (unbox datum) (unbox other-datum)))]
+    [(? vector?)
+     (and (equal? (vector-length datum) (vector-length other-datum))
+          (for/and ([substx (in-vector datum)] [other-substx (in-vector other-datum)])
+            (syntax-free-identifier=? substx other-substx)))]
+    [_ (error 'syntax-free-identifier=? "hash datum comparisons not implemented yet.")]))
+
+
+(define (syntax-pair-free-identifier=? pair other-pair)
+  (match pair
+    ['() (empty? other-pair)]
+    [(cons head (? syntax? tail))
+     (match other-pair
+       [(cons other-head (? syntax? other-tail))
+        (and (syntax-free-identifier=? head other-head)
+             (syntax-free-identifier=? tail other-tail))]
+       [_ #false])]
+    [(cons head tail)
+     (match other-pair
+       [(cons other-head other-tail)
+        (and (syntax-free-identifier=? head other-head)
+             (syntax-pair-free-identifier=? tail other-tail))]
+       [_ #false])]))
+
+
+(module+ test
+  (test-case "syntax-free-identifier=?"
+    (check-true (syntax-free-identifier=? #'5 #'5))
+    (check-false (syntax-free-identifier=? #'5 #'7))
+    (check-false (syntax-free-identifier=? #'5 #'x))
+    (check-true (syntax-free-identifier=? #'x #'x))
+    (check-true (syntax-free-identifier=? #'(x y z) #'(x y z)))
+    (check-false (syntax-free-identifier=? #'(x y z) #'(x y)))
+    (check-true (syntax-free-identifier=? #'(x (y) z) #'(x (y) z)))
+    (check-false (syntax-free-identifier=? #'(x (y) z) #'(x y z)))))


### PR DESCRIPTION
Encountered [here](https://github.com/soegaard/little-helper/blob/26249c688e5adf1e2535c405c6289030eff561b4/lexer.rkt#L61).