### PR TITLE
Tidy up gen:custom-write for code-snippet

### DIFF
--- a/code-snippet.rkt
+++ b/code-snippet.rkt
@@ -40,18 +40,20 @@
   
   #:methods gen:custom-write
   [(define (write-proc this out mode)
+     (define start-line (code-snippet-start-line this))
      (define end-line (code-snippet-end-line this))
+     (define end-line-digit-count (digit-count end-line))
+     (define leading-indentation (code-snippet-start-column this))
      (for ([line (in-lines (open-input-string (code-snippet-raw-text this)))]
            [n (in-naturals)])
        (define line-number-string
-         (~a (+ n (code-snippet-start-line this)) #:min-width (digit-count end-line)))
+         (~a (+ n start-line) #:min-width end-line-digit-count))
        (write-string line-number-string out)
        (write-string " " out)
        (cond
          [(zero? n) (write-string line out)]
          [else
-          (define leading-indentation (make-string (code-snippet-start-column this) #\space))
-          (write-string (string-replace line leading-indentation "" #:all? #false) out)])
+          (write-string (substring line leading-indentation) out)])
        (newline out)))])
 
 ; code-snippet-start-line and code-snippet-end-line give an inclusive-exclusive range; that is,

--- a/code-snippet.rkt
+++ b/code-snippet.rkt
@@ -11,7 +11,8 @@
    (-> string? exact-nonnegative-integer? exact-positive-integer? code-snippet?)]
   [code-snippet-raw-text (-> code-snippet? immutable-string?)]
   [code-snippet-start-column (-> code-snippet? exact-nonnegative-integer?)]
-  [code-snippet-start-line (-> code-snippet? exact-positive-integer?)]))
+  [code-snippet-start-line (-> code-snippet? exact-positive-integer?)]
+  [code-snippet-end-line (-> code-snippet? exact-positive-integer?)]))
 
 
 (require racket/format
@@ -53,13 +54,19 @@
           (write-string (string-replace line leading-indentation "" #:all? #false) out)])
        (newline out)))])
 
-
+; code-snippet-start-line and code-snippet-end-line give an inclusive-exclusive range; that is,
+; a one-line snippet on line 10 would have start and end lines of 10 and 11, respectively.
 (define (code-snippet-end-line snippet)
   (define line-count (sequence-length (in-lines (open-input-string (code-snippet-raw-text snippet)))))
   (+ (code-snippet-start-line snippet) line-count))
 
 
 (module+ test
+  (test-case (name-string code-snippet-end-line)
+    (test-case "end-line is one greater than the number of the last line in the snippet"
+      (define snippet (code-snippet "(+\n 1\n 2\n 3)" 0 6))
+      (check-equal? (code-snippet-end-line snippet) 10)))
+
   (test-case (name-string code-snippet)
 
     (test-case "one-line snippet"

--- a/code-snippet.rkt
+++ b/code-snippet.rkt
@@ -53,7 +53,10 @@
        (cond
          [(zero? n) (write-string line out)]
          [else
-          (write-string (substring line leading-indentation) out)])
+          (write-string (if (string-prefix? line leading-indentation)
+                            (substring line leading-indentation)
+                            line)
+                        out)])
        (newline out)))])
 
 ; code-snippet-start-line and code-snippet-end-line give an inclusive-exclusive range; that is,

--- a/code-snippet.rkt
+++ b/code-snippet.rkt
@@ -41,7 +41,7 @@
   #:methods gen:custom-write
   [(define (write-proc this out mode)
      (define start-line (code-snippet-start-line this))
-     (define end-line (code-snippet-end-line this))
+     (define end-line (sub1 (code-snippet-end-line this)))
      (define end-line-digit-count (digit-count end-line))
      (define leading-indentation (code-snippet-start-column this))
      (for ([line (in-lines (open-input-string (code-snippet-raw-text this)))]


### PR DESCRIPTION
- bring some function calls out of the loop
- use substrings instead of string replacements