### PR TITLE
Try to deflake CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           version: stable
       - run: raco pkg install --batch --auto --link --name resyntax
-      - run: xvfb-run raco test --package --drdr resyntax
+      - run: xvfb-run raco test --package resyntax


### PR DESCRIPTION
Recently, tests have been failing randomly and inconsistently with GDK errors. Working theory is that xvfb-run isn't cooperating well with the way `raco test --drdr` runs each test in a separate process and runs multiple tests in parallel. This change removes the `--drdr` mode. Note that `--package` still causes each test to run in a separate process, but (to my knowledge) does _not_ cause tests to run in parallel. So hopefully this removes the flakiness.