### PR TITLE
Fix issue where define-syntax-parse-rule is recognized as define-simple-macro

### DIFF
--- a/default-recommendations/syntax-parse-shortcuts-test.rkt
+++ b/default-recommendations/syntax-parse-shortcuts-test.rkt
@@ -52,3 +52,12 @@ test: "define-simple-macro with body comments refactorable to define-syntax-pars
   (let ([tmp a])
     (if a a b)))
 ------------------------------
+
+
+test: "define-syntax-parse-rule not refactorable (https://github.com/jackfirth/resyntax/issues/106)"
+------------------------------
+(define-syntax-parse-rule (my-or a:expr b:expr)
+  ;; The let form is needed to avoid evaluating a twice.
+  (let ([tmp a])
+    (if a a b)))
+------------------------------

--- a/default-recommendations/syntax-parse-shortcuts.rkt
+++ b/default-recommendations/syntax-parse-shortcuts.rkt
@@ -24,6 +24,12 @@
   #:description "The define-simple-macro form has been renamed to define-syntax-parse-rule."
   #:literals (define-simple-macro)
   [((~and original define-simple-macro) first-form form ...)
+
+   ;; The define-simple-macro is a renamed alias of define-syntax-parse-rule, so it's
+   ;; free-identifier=?. As a result, we need to check the actual symbol of the identifier instead of
+   ;; just its binding. See https://github.com/jackfirth/resyntax/issues/106.
+   #:when (equal? (syntax-e #'original) 'define-simple-macro)
+   
    (define-syntax-parse-rule (ORIGINAL-GAP original first-form)
      (ORIGINAL-SPLICE first-form form ...))])
 

--- a/testing/refactoring-test.rkt
+++ b/testing/refactoring-test.rkt
@@ -128,8 +128,10 @@
     (λ ()
       (with-check-info (['actual (string-block refactored-program)]
                         ['expected (string-block expected-program)])
-        (when (equal? refactored-program original-program)
+        (when (empty? results)
           (fail-check "no changes were made"))
+        (when (equal? refactored-program original-program)
+          (fail-check "fixes were made, but they left the program unchanged"))
         (when (not (equal? refactored-program expected-program))
           (with-check-info (['original (string-block original-program)])
             (fail-check "incorrect changes were made"))))
@@ -160,7 +162,10 @@
       (with-check-info (['actual (string-block refactored-program)]
                         ['original (string-block original-program)])
         (unless (equal? refactored-program original-program)
-          (fail-check "expected no changes, but changes were made"))))))
+          (fail-check "expected no changes, but changes were made")))
+      (with-check-info (['actual (string-block refactored-program)])
+        (unless (empty? results)
+          (fail-check "the program was not changed, but no-op fixes were suggested"))))))
 
 
 (define-simple-macro (refactoring-test-case name:str input:str (~optional expected:str))


### PR DESCRIPTION
Fixes #106. Also, this improves the testing infrastructure to tell the difference between no refactoring rules matching the input and rules matching but producing no-op fixes.