### PR TITLE
Allow specifying multiple inputs in refactoring tests

### DIFF
--- a/default-recommendations/comparison-shortcuts-test.rkt
+++ b/default-recommendations/comparison-shortcuts-test.rkt
@@ -12,41 +12,27 @@ header:
 ------------------------------
 
 
-test: "(> (- x y) 0) refactorable to direct comparison"
+test: "comparison of difference to zero refactorable to direct > comparison"
 - (> (- x y) 0)
+- (<= 0 (- x y))
 - (> x y)
 
 
-test: "(< (- x y) 0) refactorable to direct comparison"
+test: "comparison of difference to zero refactorable to direct < comparison"
 - (< (- x y) 0)
-- (< x y)
-
-
-test: "(>= (- x y) 0) refactorable to direct comparison"
-- (>= (- x y) 0)
-- (>= x y)
-
-
-test: "(<= (- x y) 0) refactorable to direct comparison"
-- (<= (- x y) 0)
-- (<= x y)
-
-
-test: "(> 0 (- x y)) refactorable to direct comparison"
-- (> 0 (- x y))
-- (<= x y)
-
-
-test: "(< 0 (- x y)) refactorable to direct comparison"
-- (< 0 (- x y))
-- (>= x y)
-
-
-test: "(>= 0 (- x y)) refactorable to direct comparison"
 - (>= 0 (- x y))
 - (< x y)
 
 
-test: "(<= 0 (- x y)) refactorable to direct comparison"
-- (<= 0 (- x y))
-- (> x y)
+test: "comparison of difference to zero refactorable to direct >= comparison"
+- (< 0 (- x y))
+- (>= (- x y) 0)
+- (>= x y)
+
+
+test: "comparison of difference to zero refactorable to direct <= comparison"
+- (> 0 (- x y))
+- (<= (- x y) 0)
+- (<= x y)
+
+

--- a/testing/refactoring-test-parser.rkt
+++ b/testing/refactoring-test-parser.rkt
@@ -3,4 +3,4 @@
 refactoring-test: refactoring-test-import* refactoring-test-header? refactoring-test-case*
 refactoring-test-import: /REQUIRE-KEYWORD IDENTIFIER IDENTIFIER
 refactoring-test-header: /HEADER-KEYWORD CODE-BLOCK
-refactoring-test-case: /TEST-KEYWORD STRING-LITERAL CODE-BLOCK{1,2}
+refactoring-test-case: /TEST-KEYWORD STRING-LITERAL CODE-BLOCK+


### PR DESCRIPTION
The test checks that *each input* produces the expected output (the last code block/line is always the expected output). This makes it easier to write tests for conditionals and comparisons, since those test cases tend to have a combinatorial explosion in the number of ways that the same code can be written.