### PR TITLE
Convert rule descriptions to Markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,8 @@
 To install locally for development, run `raco pkg install --auto --link
 --installation`.
 
+To run the tests, use `raco test -p resyntax`.
+
 It is **recommended** to use either [DrRacket][dr] or [racket-langserver][rls]
 with the latest [Racket][rkt] (not `racket-minimal`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing / development guidelines
+
+To install locally for development, run `raco pkg install --auto --link
+--installation`.
+
+It is **recommended** to use either [DrRacket][dr] or [racket-langserver][rls]
+with the latest [Racket][rkt] (not `racket-minimal`).
+
+[dr]: https://docs.racket-lang.org/drracket/
+[rls]: https://pkgs.racket-lang.org/package/racket-langserver
+[rkt]: https://download.racket-lang.org/

--- a/default-recommendations/boolean-shortcuts.rkt
+++ b/default-recommendations/boolean-shortcuts.rkt
@@ -24,7 +24,7 @@
 
 
 (define-refactoring-rule nested-or-to-flat-or
-  #:description "Nested or expressions can be flattened to a single, equivalent or expression."
+  #:description "Nested `or` expressions can be flattened into a single, equivalent `or` expression."
   [or-tree
    #:declare or-tree (syntax-tree #'or)
    ;; Restricted to single-line expressions for now because the syntax-tree operations don't preserve
@@ -35,7 +35,7 @@
 
 
 (define-refactoring-rule nested-and-to-flat-and
-  #:description "Nested and expressions can be flattened to a single, equivalent and expression."
+  #:description "Nested `and` expressions can be flattened into a single, equivalent `and` expression."
   [and-tree
    #:declare and-tree (syntax-tree #'and)
    ;; Restricted to single-line expressions for now because the syntax-tree operations don't preserve
@@ -64,21 +64,21 @@
 
 
 (define-refactoring-rule if-then-true-else-false-to-condition
-  #:description "The condition of this if expression is already a boolean and can be used directly."
+  #:description "The condition of this `if` expression is already a boolean and can be used directly."
   #:literals (if)
   [(if condition:likely-boolean #true #false)
    condition])
 
 
 (define-refactoring-rule if-then-false-else-true-to-not
-  #:description "This if expression can be refactored to an equivalent expression using not."
+  #:description "This `if` expression can be refactored to an equivalent expression using `not`."
   #:literals (if)
   [(if condition #false #true)
    (not condition)])
 
 
 (define-refactoring-rule if-else-false-to-and
-  #:description "This if expression can be refactored to an equivalent expression using and."
+  #:description "This `if` expression can be refactored to an equivalent expression using `and`."
   #:literals (if)
   [(if condition then #false)
    (and (ORIGINAL-SPLICE condition then))])
@@ -94,7 +94,7 @@
 
 
 (define-refactoring-rule inverted-unless
-  #:description "This negated unless expression can be replaced by a when expression."
+  #:description "This negated `unless` expression can be replaced by a `when` expression."
   #:literals (unless not)
   [(unless (~and negated (not condition))
      body0 body ...)

--- a/default-recommendations/comparison-shortcuts.rkt
+++ b/default-recommendations/comparison-shortcuts.rkt
@@ -98,14 +98,14 @@
 
 (define-refactoring-rule two-exclusive-comparisons-to-triple-comparison
   #:description
-  "Comparison functions like < accept multiple arguments, so this condition can be simplified."
+  "Comparison functions like `<` accept multiple arguments, so this condition can be simplified."
   [comparison:two-exclusive-comparisons
    (< comparison.lower-bound comparison.x comparison.upper-bound)])
 
 
 (define-refactoring-rule two-inclusive-comparisons-to-triple-comparison
   #:description
-  "Comparison functions like <= accept multiple arguments, so this condition can be simplified."
+  "Comparison functions like `<=` accept multiple arguments, so this condition can be simplified."
   [comparison:two-inclusive-comparisons
    (<= comparison.lower-bound comparison.x comparison.upper-bound)])
 

--- a/default-recommendations/conditional-shortcuts.rkt
+++ b/default-recommendations/conditional-shortcuts.rkt
@@ -38,7 +38,7 @@
 
 
 (define-refactoring-rule nested-if-to-cond
-  #:description "This if-else chain can be converted to a cond expression."
+  #:description "This `if`-`else` chain can be converted to a `cond` expression."
   #:literals (cond)
   [nested:nested-if-else
    #:when (> (attribute nested.branches-size) 2)
@@ -90,7 +90,7 @@
 
 
 (define-refactoring-rule always-throwing-if-to-when
-  #:description "Using when and unless is simplier than a conditional with an always-throwing branch."
+  #:description "Using `when` and `unless` is simplier than a conditional with an always-throwing branch."
   #:literals (if)
   [(header:header-form-allowing-internal-definitions
     (if condition:condition-expression
@@ -103,7 +103,7 @@
 
 
 (define-refactoring-rule always-throwing-cond-to-when
-  #:description "Using when and unless is simplier than a conditional with an always-throwing branch."
+  #:description "Using `when` and `unless` is simplier than a conditional with an always-throwing branch."
   #:literals (cond)
   [(header:header-form-allowing-internal-definitions
     (cond
@@ -119,7 +119,7 @@
 
 (define-refactoring-rule cond-else-cond-to-cond
   #:description
-  "The else clause of this cond expression is another cond expression and can be flattened."
+  "The `else` clause of this `cond` expression is another `cond` expression and can be flattened."
   #:literals (cond else)
   [((~and outer-cond-id cond)
      clause ... last-non-else-clause

--- a/default-recommendations/conditional-shortcuts.rkt
+++ b/default-recommendations/conditional-shortcuts.rkt
@@ -90,7 +90,7 @@
 
 
 (define-refactoring-rule always-throwing-if-to-when
-  #:description "Using `when` and `unless` is simplier than a conditional with an always-throwing branch."
+  #:description "Using `when` and `unless` is simpler than a conditional with an always-throwing branch."
   #:literals (if)
   [(header:header-form-allowing-internal-definitions
     (if condition:condition-expression

--- a/default-recommendations/conditional-shortcuts.rkt
+++ b/default-recommendations/conditional-shortcuts.rkt
@@ -103,7 +103,7 @@
 
 
 (define-refactoring-rule always-throwing-cond-to-when
-  #:description "Using `when` and `unless` is simplier than a conditional with an always-throwing branch."
+  #:description "Using `when` and `unless` is simpler than a conditional with an always-throwing branch."
   #:literals (cond)
   [(header:header-form-allowing-internal-definitions
     (cond

--- a/default-recommendations/contract-shortcuts.rkt
+++ b/default-recommendations/contract-shortcuts.rkt
@@ -22,7 +22,7 @@
 
 
 (define-refactoring-rule nested-or/c-to-flat-or/c
-  #:description "Nested or/c contracts can be flattened to a single, equivalent or/c contract."
+  #:description "Nested `or/c` contracts can be flattened to a single, equivalent `or/c` contract."
   [or-tree
    #:declare or-tree (syntax-tree #'or/c)
    ;; Restricted to single-line expressions for now because the syntax-tree operations don't preserve
@@ -33,7 +33,7 @@
 
 
 (define-refactoring-rule nested-and/c-to-flat-and/c
-  #:description "Nested and/c contracts can be flattened to a single, equivalent and/c contract."
+  #:description "Nested `and/c` contracts can be flattened to a single, equivalent `and/c` contract."
   [and-tree
    #:declare and-tree (syntax-tree #'and/c)
    ;; Restricted to single-line expressions for now because the syntax-tree operations don't preserve
@@ -44,7 +44,7 @@
 
 
 (define-refactoring-rule explicit-predicate/c-to-predicate/c
-  #:description "This contract is equivalent to the predicate/c contract."
+  #:description "This contract is equivalent to the `predicate/c` contract."
   #:literals (-> any/c boolean?)
   [(-> any/c boolean?)
    predicate/c])

--- a/default-recommendations/for-loop-shortcuts.rkt
+++ b/default-recommendations/for-loop-shortcuts.rkt
@@ -110,7 +110,7 @@
 
 
 (define-refactoring-rule apply-plus-to-for/sum
-  #:description "Applying + to a list of numbers can be replaced with a for/sum loop."
+  #:description "Applying `+` to a list of numbers can be replaced with a `for/sum` loop."
   #:literals (apply +)
   [(apply + loop:for-loop-convertible-list-expression)
    ((~if loop.nesting-loop? for*/sum for/sum) loop.loop-clauses (~@ NEWLINE loop.loop-body) ...)])
@@ -143,7 +143,7 @@
 
 
 (define-refactoring-rule for-each-to-for
-  #:description "This for-each operation can be replaced with a for loop."
+  #:description "This `for-each` operation can be replaced with a `for` loop."
   #:literals (for-each)
   [(for-each function:worthwhile-loop-body-function loop:for-clause-convertible-list-expression)
    ((~if loop.flat? for for*)
@@ -152,7 +152,7 @@
 
 
 (define-refactoring-rule ormap-to-for/or
-  #:description "This ormap operation can be replaced with a for/or loop."
+  #:description "This `ormap` operation can be replaced with a `for/or` loop."
   #:literals (ormap)
   [(ormap function:worthwhile-loop-body-function loop:for-clause-convertible-list-expression)
    ((~if loop.flat? for/or for*/or)
@@ -161,7 +161,7 @@
 
 
 (define-refactoring-rule andmap-to-for/and
-  #:description "This andmap operation can be replaced with a for/and loop."
+  #:description "This `andmap` operation can be replaced with a `for/and` loop."
   #:literals (andmap)
   [(andmap function:worthwhile-loop-body-function loop:for-clause-convertible-list-expression)
    ((~if loop.flat? for/and for*/and)
@@ -170,7 +170,7 @@
 
 
 (define-refactoring-rule list->vector-for/list-to-for/vector
-  #:description "For loops can build vectors directly."
+  #:description "`for` loops can build vectors directly."
   #:literals (list->vector for/list for*/list)
   [(list->vector
     ((~or (~and for/list (~bind [loop #'for/vector])) (~and for*/list (~bind [loop #'for*/vector])))
@@ -179,7 +179,7 @@
 
 
 (define-refactoring-rule for/fold-building-hash-to-for/hash
-  #:description "This for loop is building a hash and can be simplified."
+  #:description "This `for` loop is building a hash and can be simplified."
   #:literals (for/fold for*/fold hash make-immutable-hash)
   [((~or (~and for/fold (~bind [loop #'for/hash])) (~and for*/fold (~bind [loop #'for*/hash])))
     ([h:id (~or (hash) (make-immutable-hash))]) iteration-clauses
@@ -204,7 +204,7 @@
 
 
 (define-refactoring-rule nested-for-to-for*
-  #:description "These nested for loops can be replaced by a single for* loop."
+  #:description "These nested `for` loops can be replaced by a single `for*` loop."
   [nested:nested-for
    #:when (>= (length (attribute nested.clause)) 2)
    (for* (nested.clause ...) NEWLINE
@@ -212,7 +212,7 @@
 
 
 (define-refactoring-rule named-let-loop-to-for/first-in-vector
-  #:description "This loop can be replaced by a simpler, equivalent for/first loop."
+  #:description "This loop can be replaced by a simpler, equivalent `for/first` loop."
   #:literals (let add1 + vector-length vector-ref if and <)
   [(let loop1:id ([i1:id 0])
      (and (< i2:id (vector-length vec1:id))
@@ -231,7 +231,7 @@
 
 
 (define-refactoring-rule or-in-for/and-to-filter-clause
-  #:description "The or expression in this for loop can be replaced by a filtering clause."
+  #:description "The `or` expression in this `for` loop can be replaced by a filtering clause."
   #:literals (for/and for*/and or)
   [((~and loop-id (~or for/and for*/and))
     (~and original-clauses (clause ...))

--- a/default-recommendations/function-definition-shortcuts.rkt
+++ b/default-recommendations/function-definition-shortcuts.rkt
@@ -74,7 +74,7 @@
 
 (define-refactoring-rule define-lambda-to-define
   #:description
-  "The define form supports a shorthand for defining functions (including function-returning\
+  "The `define` form supports a shorthand for defining functions (including function-returning\
  functions)."
   #:literals (define)
   [(define header lambda-form:possibly-nested-lambdas)
@@ -88,7 +88,7 @@
 
 
 (define-refactoring-rule define-case-lambda-to-define
-  #:description "This use of case-lambda is equivalent to using define with optional arguments."
+  #:description "This use of `case-lambda` is equivalent to using `define` with optional arguments."
   #:literals (define case-lambda)
   [(define id:id
      (case-lambda

--- a/default-recommendations/hash-shortcuts.rkt
+++ b/default-recommendations/hash-shortcuts.rkt
@@ -25,14 +25,14 @@
 
 
 (define-refactoring-rule hash-ref-with-constant-lambda-to-hash-ref-without-lambda
-  #:description "The lambda can be removed from the failure result in this hash-ref expression."
+  #:description "The lambda can be removed from the failure result in this `hash-ref` expression."
   #:literals (hash-ref)
   [((~and ref hash-ref) h:expr k:expr (~and lambda-expr (_:lambda-by-any-name () v:literal-constant)))
    ((ORIGINAL-SPLICE ref h k) (ORIGINAL-GAP k lambda-expr) v)])
 
 
 (define-refactoring-rule hash-ref!-with-constant-lambda-to-hash-ref!-without-lambda
-  #:description "The lambda can be removed from the failure result in this hash-ref! expression."
+  #:description "The lambda can be removed from the failure result in this `hash-ref!` expression."
   #:literals (hash-ref!)
   [((~and ref hash-ref!) h:expr k:expr
                          (~and lambda-expr (_:lambda-by-any-name () v:literal-constant)))
@@ -47,7 +47,7 @@
 
 
 (define-refactoring-rule hash-ref-set!-to-hash-ref!
-  #:description "This expression can be replaced with a simpler, equivalent hash-ref! expression."
+  #:description "This expression can be replaced with a simpler, equivalent `hash-ref!` expression."
   #:literals (hash-ref hash-set! define)
   [(hash-ref
     h1:id
@@ -65,7 +65,7 @@
 
 
 (define-refactoring-rule hash-ref-set!-with-constant-to-hash-ref!
-  #:description "This expression can be replaced with a simpler, equivalent hash-ref! expression."
+  #:description "This expression can be replaced with a simpler, equivalent `hash-ref!` expression."
   #:literals (hash-ref hash-set! define)
   [(hash-ref
     h1:id
@@ -81,7 +81,7 @@
 
 
 (define-refactoring-rule hash-set!-ref-to-hash-update!
-  #:description "This expression can be replaced with a simpler, equivalent hash-update! expression."
+  #:description "This expression can be replaced with a simpler, equivalent `hash-update!` expression."
   #:literals (hash-ref hash-set!)
   [(hash-set! h1:id k1:id
               (f:id arg-before:expr ...

--- a/default-recommendations/legacy-contract-migrations.rkt
+++ b/default-recommendations/legacy-contract-migrations.rkt
@@ -20,37 +20,37 @@
 
 
 (define-refactoring-rule false/c-migration
-  #:description "false/c is an alias for #f that exists for backwards compatibility."
+  #:description "`false/c` is an alias for `#f` that exists for backwards compatibility."
   #:literals (false/c)
   [false/c
    #false])
 
 
 (define-refactoring-rule symbols-migration
-  #:description "symbols is equivalent to or/c and exists for backwards compatibility."
+  #:description "`symbols` is equivalent to `or/c` and exists for backwards compatibility."
   #:literals (symbols)
   [(symbols sym ...)
    (or/c sym ...)])
 
 
 (define-refactoring-rule vector-immutableof-migration
-  #:description "vector-immutableof is a legacy form that is equivalent to vectorof with the\
- #:immutable option"
+  #:description "`vector-immutableof` is a legacy form that is equivalent to `vectorof` with the\
+ `#:immutable` option"
   #:literals (vector-immutableof)
   [(vector-immutableof c)
    (vectorof c #:immutable #true)])
 
 
 (define-refactoring-rule vector-immutable/c-migration
-  #:description "vector-immutable/c is a legacy form that is equivalent to vector/c with the\
- #:immutable option"
+  #:description "`vector-immutable/c` is a legacy form that is equivalent to `vector/c` with the\
+ `#:immutable` option"
   #:literals (vector-immutable/c)
   [(vector-immutable/c c ...)
    (vector/c c ... #:immutable #true)])
 
 
 (define-refactoring-rule box-immutable/c-migration
-  #:description "box-immutable/c is a legacy form that is equivalent to box/c with the #:immutable\
+  #:description "`box-immutable/c` is a legacy form that is equivalent to `box/c` with the `#:immutable`\
  option"
   #:literals (box-immutable/c)
   [(box-immutable/c c)
@@ -66,7 +66,7 @@
 
 
 (define-refactoring-rule contract-struct-migration
-  #:description "The contract-struct form is deprecated, use struct instead. Lazy struct contracts no\
+  #:description "The `contract-struct` form is deprecated; use `struct` instead. Lazy struct contracts no\
  longer require a separate struct declaration."
   #:literals (contract-struct)
   [(contract-struct id fields)
@@ -74,7 +74,7 @@
 
 
 (define-refactoring-rule define-contract-struct-migration
-  #:description "The define-contract-struct form is deprecated, use struct instead. Lazy struct\
+  #:description "The `define-contract-struct` form is deprecated, use `struct` instead. Lazy struct\
  contracts no longer require a separate struct declaration."
   #:literals (define-contract-struct)
   [(define-contract-struct id fields)

--- a/default-recommendations/legacy-struct-migrations.rkt
+++ b/default-recommendations/legacy-struct-migrations.rkt
@@ -45,7 +45,7 @@
 
 
 (define-refactoring-rule define-struct-to-struct
-  #:description "The define-struct form exists for backwards compatibility, struct is preferred."
+  #:description "The `define-struct` form exists for backwards compatibility, `struct` is preferred."
   #:literals (define-struct)
   [(define-struct id:id-maybe-super fields option:struct-option ...)
    (struct id.migrated ... (ORIGINAL-SPLICE fields option.original ... ...)

--- a/default-recommendations/legacy-syntax-migrations.rkt
+++ b/default-recommendations/legacy-syntax-migrations.rkt
@@ -21,35 +21,35 @@
 
 
 (define-refactoring-rule datum->syntax-migration
-  #:description "The fifth argument to datum->syntax is ignored."
+  #:description "The fifth argument to `datum->syntax` is ignored."
   #:literals (datum->syntax)
   [((~and id datum->syntax) ctxt v srcloc prop ignored)
    ((ORIGINAL-SPLICE id ctxt v srcloc prop))])
 
 
 (define-refactoring-rule syntax-recertify-migration
-  #:description "The syntax-recertify function is a legacy function that does nothing."
+  #:description "The `syntax-recertify` function is a legacy function that does nothing."
   #:literals (syntax-recertify)
   [(syntax-recertify stx _ _ _)
    stx])
 
 
 (define-refactoring-rule syntax-disarm-migration
-  #:description "The syntax-disarm function is a legacy function that does nothing."
+  #:description "The `syntax-disarm` function is a legacy function that does nothing."
   #:literals (syntax-disarm)
   [(syntax-disarm stx _)
    stx])
 
 
 (define-refactoring-rule syntax-rearm-migration
-  #:description "The syntax-rearm function is a legacy function that does nothing."
+  #:description "The `syntax-rearm` function is a legacy function that does nothing."
   #:literals (syntax-rearm)
   [(syntax-rearm stx _ ...)
    stx])
 
 
 (define-refactoring-rule syntax-protect-migration
-  #:description "The syntax-protect function is a legacy function that does nothing."
+  #:description "The `syntax-protect` function is a legacy function that does nothing."
   #:literals (syntax-protect)
   [(syntax-protect stx)
    stx])

--- a/default-recommendations/let-binding-suggestions.rkt
+++ b/default-recommendations/let-binding-suggestions.rkt
@@ -39,15 +39,15 @@
 
 
 (define-refactoring-rule let-to-define
-  #:description "Internal definitions are recommended instead of let expressions, to reduce nesting."
+  #:description "Internal definitions are recommended instead of `let` expressions, to reduce nesting."
   [(header:header-form-allowing-internal-definitions let-expr:body-with-refactorable-let-expression)
    (header.formatted ... let-expr.refactored ...)])
 
 
 (define-refactoring-rule named-let-to-plain-let
   #:description
-  "This named let loop doesn't actually perform any recursive calls, and can be replaced with an\
- unnamed let."
+  "This named `let` loop doesn't actually perform any recursive calls, and can be replaced with an\
+ unnamed `let`."
   #:literals (let)
   [(let name:id header body ...)
    #:when (not (set-member? (syntax-free-identifiers #'(body ...)) #'name))
@@ -56,7 +56,7 @@
 
 (define-refactoring-rule let-values-then-call-to-call-with-values
   #:description
-  "This let-values expression can be replaced with a simpler, equivalent call-with-values expression."
+  "This `let-values` expression can be replaced with a simpler, equivalent `call-with-values` expression."
   #:literals (let-values)
   [(let-values ([(bound-id:id ...+) expr])
      (receiver:id arg-id:id ...+))

--- a/default-recommendations/list-shortcuts.rkt
+++ b/default-recommendations/list-shortcuts.rkt
@@ -22,7 +22,7 @@
 
 
 (define-refactoring-rule first-reverse-to-last
-  #:description "The last function can be used to get the last item from a list."
+  #:description "The `last` function can be used to get the last item from a list."
   #:literals (first reverse)
   ;; This can't match (car (reverse list)) because of https://github.com/jackfirth/resyntax/issues/11
   [(first (reverse list))
@@ -38,19 +38,19 @@
 
 ;; This can't suggest using empty? because of https://github.com/jackfirth/resyntax/issues/11
 (define-refactoring-rule equal-null-list-to-null-predicate
-  #:description "The null? predicate can be used to test for the empty list."
+  #:description "The `null?` predicate can be used to test for the empty list."
   [test:null-test (null? test.subject)])
 
 
 (define-refactoring-rule list-call-to-empty-list-literal
-  #:description "An empty list literal can be written as '()."
+  #:description "An empty list literal can be written as `'()`."
   #:literals (list)
   [(list)
    '()])
 
 
 (define-refactoring-rule null-to-empty-list-literal
-  #:description "The preferred way to write the empty list is '()."
+  #:description "The preferred way to write the empty list is `'()`."
   #:literals (null)
   [null
    '()])
@@ -58,21 +58,21 @@
 
 (define-refactoring-rule append*-and-map-to-append-map
   #:description
-  "The append-map function can be used to map each element into multiple elements in a single pass."
+  "The `append-map` function can be used to map each element into multiple elements in a single pass."
   #:literals (append* map)
   [(append* (map f lst))
    (append-map f lst)])
 
 
 (define-refactoring-rule append-single-list-to-single-list
-  #:description "The append function does nothing when applied to only one list."
+  #:description "The `append` function does nothing when applied to only one list."
   #:literals (append)
   [(append lst)
    lst])
 
 
 (define-refactoring-rule sort-with-keyed-comparator-to-sort-by-key
-  #:description "This sort expression can be replaced with a simpler, equivalent expression."
+  #:description "This `sort` expression can be replaced with a simpler, equivalent expression."
   #:literals (sort <)
   [(sort lst (_:lambda-by-any-name (x1:id y1:id) (less-than:id (f1:id x2:id) (f2:id y2:id))))
    #:when (free-identifier=? #'x1 #'x2)

--- a/default-recommendations/match-shortcuts.rkt
+++ b/default-recommendations/match-shortcuts.rkt
@@ -25,7 +25,7 @@
 
 
 (define-refactoring-rule single-clause-match-to-match-define
-  #:description "This match expression can be simplified using match-define."
+  #:description "This `match` expression can be simplified using `match-define`."
   #:literals (match)
   [(header:header-form-allowing-internal-definitions
     (match subject

--- a/default-recommendations/miscellaneous-suggestions.rkt
+++ b/default-recommendations/miscellaneous-suggestions.rkt
@@ -22,7 +22,7 @@
 
 
 (define if-begin-to-cond-message
-  "The cond form supports multiple body expressions in each branch, making begin unnecessary.")
+  "The `cond` form supports multiple body expressions in each branch, making `begin` unnecessary.")
 
 (define-refactoring-rule if-then-begin-to-cond
   #:description if-begin-to-cond-message
@@ -52,7 +52,7 @@
 
 
 (define-refactoring-rule cond-else-if-to-cond
-  #:description "The else if branch of this cond expression can be collapsed into the cond\
+  #:description "The `else`-`if` branch of this `cond` expression can be collapsed into the `cond`\
  expression."
   #:literals (cond else if)
   [(cond clause ... [else (if inner-condition inner-then-branch else-branch)])
@@ -63,7 +63,7 @@
 
 
 (define-refactoring-rule cond-begin-to-cond
-  #:description "The bodies of cond clauses are already implicitly wrapped in begin."
+  #:description "The bodies of `cond` clauses are already implicitly wrapped in `begin`."
   #:literals (cond begin)
   [(cond clause-before ...
          [condition (begin body ...)]
@@ -75,7 +75,7 @@
 
 
 (define-refactoring-rule or-cond-to-cond
-  #:description "This or expression can be turned into a clause of the inner cond expression,\
+  #:description "This `or` expression can be turned into a clause of the inner `cond` expression,\
  reducing nesting."
   #:literals (or cond)
   [(or condition (cond clause ...))
@@ -85,7 +85,7 @@
 
 
 (define-refactoring-rule and-match-to-match
-  #:description "This and expression can be turned into a clause of the inner match expression,\
+  #:description "This `and` expression can be turned into a clause of the inner `match` expression,\
  reducing nesting."
   #:literals (and match)
   [(and and-subject:id (match match-subject:id match-clause ...))

--- a/default-recommendations/numeric-shortcuts.rkt
+++ b/default-recommendations/numeric-shortcuts.rkt
@@ -20,7 +20,7 @@
 
 
 (define-refactoring-rule add1-lambda-to-add1
-  #:description "This lambda function is equivalent to the built-in add1 function."
+  #:description "This lambda function is equivalent to the built-in `add1` function."
   #:literals (+)
   [(lambda:lambda-by-any-name (x1:id) (~or (+ x2:id 1) (+ 1 x2:id)))
    #:when (free-identifier=? #'x1 #'x2)
@@ -28,7 +28,7 @@
 
 
 (define-refactoring-rule sub1-lambda-to-sub1
-  #:description "This lambda function is equivalent to the built-in sub1 function."
+  #:description "This lambda function is equivalent to the built-in `sub1` function."
   #:literals (+ -)
   [(lambda:lambda-by-any-name (x1:id) (~or (- x2:id 1) (+ x2:id -1) (+ -1 x2:id)))
    #:when (free-identifier=? #'x1 #'x2)
@@ -36,7 +36,7 @@
 
 
 (define-refactoring-rule zero-comparison-lambda-to-positive?
-  #:description "This lambda function is equivalent to the built-in positive? predicate."
+  #:description "This lambda function is equivalent to the built-in `positive?` predicate."
   #:literals (< >)
   [(lambda:lambda-by-any-name (x1:id) (~or (> x2:id 0) (< 0 x2:id)))
    #:when (free-identifier=? #'x1 #'x2)
@@ -44,7 +44,7 @@
 
 
 (define-refactoring-rule zero-comparison-lambda-to-negative?
-  #:description "This lambda function is equivalent to the built-in negative? predicate."
+  #:description "This lambda function is equivalent to the built-in `negative?` predicate."
   #:literals (< >)
   [(lambda:lambda-by-any-name (x1:id) (~or (< x2:id 0) (> 0 x2:id)))
    #:when (free-identifier=? #'x1 #'x2)

--- a/default-recommendations/syntax-parse-shortcuts.rkt
+++ b/default-recommendations/syntax-parse-shortcuts.rkt
@@ -21,7 +21,7 @@
 
 
 (define-refactoring-rule define-simple-macro-to-define-syntax-parse-rule
-  #:description "The define-simple-macro form has been renamed to define-syntax-parse-rule."
+  #:description "The `define-simple-macro` form has been renamed to `define-syntax-parse-rule`."
   #:literals (define-simple-macro)
   [((~and original define-simple-macro) first-form form ...)
 

--- a/default-recommendations/syntax-rules-shortcuts.rkt
+++ b/default-recommendations/syntax-rules-shortcuts.rkt
@@ -20,7 +20,7 @@
 
 
 (define-refactoring-rule define-syntax-syntax-rules-to-define-syntax-rule
-  #:description "This macro can be replaced with a simpler, equivalent define-syntax-rule macro."
+  #:description "This `define-syntax` macro can be replaced with a simpler, equivalent `define-syntax-rule` macro."
   #:literals (define-syntax syntax-rules)
   [(define-syntax macro:id
      (syntax-rules () [(_ . pattern) template]))

--- a/private/github.rkt
+++ b/private/github.rkt
@@ -149,13 +149,14 @@
   (define replacement (refactoring-result-line-replacement result))
   (define body
     (format #<<EOS
-**`~a`** ~a
+**`~a`:** ~a
 
 ```suggestion
 ~a
 ```
 
-Debugging details below:
+<details>
+<summary>Debugging details</summary>
 
 <details>
   <summary>Textual replacement</summary>
@@ -171,6 +172,7 @@ Debugging details below:
   ```scheme
 ~a
   ```
+</details>
 </details>
 EOS
             (refactoring-result-rule-name result)


### PR DESCRIPTION
Also adds a `CONTRIBUTING.md` for the next time I forget the exact `raco pkg` command needed to hack on this.

Future work: hyperlinks to the docs for all those identifiers!