### PR TITLE
Only analyze modified lines of git refs

### DIFF
--- a/cli.rkt
+++ b/cli.rkt
@@ -8,9 +8,12 @@
          racket/match
          racket/path
          racket/string
+         rebellion/base/comparator
+         rebellion/base/range
          rebellion/collection/entry
          rebellion/collection/hash
          rebellion/collection/list
+         rebellion/collection/range-set
          rebellion/collection/vector/builder
          rebellion/streaming/reducer
          rebellion/streaming/transducer
@@ -33,6 +36,9 @@
 (define-record-type resyntax-fix-options (targets suite))
 
 
+(define all-lines (range-set (unbounded-range #:comparator natural<=>)))
+
+
 (define (resyntax-analyze-parse-command-line)
   (define targets (make-vector-builder))
   (define suite default-recommendations)
@@ -41,7 +47,10 @@
   (command-line
    #:program "resyntax analyze"
    #:multi
-   ("--file" filepath "A file to analyze." (vector-builder-add targets (single-file-group filepath)))
+   ("--file"
+    filepath
+    "A file to analyze."
+    (vector-builder-add targets (single-file-group filepath all-lines)))
    ("--directory"
     dirpath
     "A directory to anaylze, including subdirectories."
@@ -88,7 +97,7 @@ determined by the GITHUB_REPOSITORY and GITHUB_REF environment variables."
   (command-line
    #:program "resyntax fix"
    #:multi
-   ("--file" filepath "A file to fix." (add-target! (single-file-group filepath)))
+   ("--file" filepath "A file to fix." (add-target! (single-file-group filepath all-lines)))
    ("--directory"
     dirpath
     "A directory to fix, including subdirectories."

--- a/private/file-group.rkt
+++ b/private/file-group.rkt
@@ -6,7 +6,11 @@
 
 (provide
  (contract-out
-  [file-groups-resolve (-> (sequence/c file-group?) (listof complete-path?))]
+  [file-portion? predicate/c]
+  [file-portion (-> path-string? range-set? file-portion?)]
+  [file-portion-path (-> file-portion? complete-path?)]
+  [file-portion-lines (-> file-portion? range-set?)]
+  [file-groups-resolve (-> (sequence/c file-group?) (listof file-portion?))]
   [file-group? predicate/c]
   [single-file-group? predicate/c]
   [single-file-group (-> path-string? single-file-group?)]
@@ -25,7 +29,10 @@
          racket/path
          racket/sequence
          racket/string
+         rebellion/base/comparator
+         rebellion/base/range
          rebellion/collection/list
+         rebellion/collection/range-set
          rebellion/private/guarded-block
          rebellion/streaming/transducer
          resyntax/private/run-command)
@@ -34,10 +41,15 @@
 ;@----------------------------------------------------------------------------------------------------
 
 
+(struct file-portion (path lines)
+  #:transparent
+  #:guard (λ (path lines _) (values (simple-form-path path) lines)))
+
+
 (struct file-group () #:transparent)
 
 
-(struct single-file-group file-group (path)
+(struct single-file-group file-group (path ranges)
   #:transparent
   #:guard (λ (path _) (simple-form-path path)))
 
@@ -60,25 +72,40 @@
 
 
 (define (file-groups-resolve groups)
-  (transduce groups (append-mapping file-group-resolve) (deduplicating) #:into into-list))
+  (transduce groups
+             (append-mapping file-group-resolve)
+
+             ;; TODO: this is incorrect - there could be overlapping portions of the same file. The
+             ;; fix is to group the portions by filename and merge their range sets together. I don't
+             ;; think I've implemented that operation for range sets yet so I'll get back to that. The
+             ;; bug only occurs if the same file is included in multiple groups with different ranges.
+             (deduplicating)
+
+             #:into into-list))
 
 
 (define (file-group-resolve group)
   (define files
     (match group
-      [(single-file-group path) (list path)]
-      [(directory-file-group path) (sequence->list (in-directory path))]
+      [(single-file-group path ranges)
+       (list (file-portion path ranges))]
+      [(directory-file-group path)
+       (for/list ([file (in-directory path)])
+         (file-portion file (range-set (unbounded-range #:comparator natural<=>))))]
       [(package-file-group package-name)
-       (sequence->list (in-directory (simple-form-path (pkg-directory package-name))))]
+       (for/list ([file (in-directory (simple-form-path (pkg-directory package-name)))])
+         (file-portion file (range-set (unbounded-range #:comparator natural<=>))))]
       [(git-repository-file-group repository-path ref)
        (parameterize ([current-directory repository-path])
-         (define null-separated-filenames (run-command "git" "diff" "--name-only" "-z" "--diff-filter=AM" ref "--"))
-         (for/list ([filename (string-split null-separated-filenames "\0")])
-           (simple-form-path filename)))]))
+         (define null-separated-filenames
+           (run-command "git" "diff" "--name-only" "-z" "--diff-filter=AM" ref "--"))
+         (for/list ([file (string-split null-separated-filenames "\0")])
+           (file-portion file (range-set (unbounded-range #:comparator natural<=>)))))]))
   (transduce files (filtering rkt-file?) #:into into-list))
 
 
-(define/guard (rkt-file? path)
+(define/guard (rkt-file? portion)
+  (define path (file-portion-path portion))
   (guard (path-has-extension? path #".rkt") else
     #false)
   (define content (file->string path))

--- a/private/git.rkt
+++ b/private/git.rkt
@@ -1,0 +1,66 @@
+#lang racket/base
+
+
+(require racket/contract)
+
+
+(provide
+ (contract-out
+  [git-diff-modified-lines (-> string? (hash/c path? immutable-range-set?))]))
+
+
+(require fancy-app
+         racket/match
+         racket/port
+         racket/string
+         racket/system
+         rebellion/base/comparator
+         rebellion/base/option
+         rebellion/base/range
+         rebellion/collection/range-set)
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+
+(define (git-diff-modified-lines ref)
+  (define cmd
+    (format
+     "git diff -U0 --inter-hunk-context=0 --diff-filter=AM ~a | grep -e '^+++ b/' -e '^@@'" ref))
+  (define empty-lines (range-set #:comparator natural<=>))
+  (for*/fold ([files (hash)]
+              [current-file #false]
+              #:result files)
+             ([line (in-list (string-split (with-output-to-string (λ () (system cmd))) "\n"))]
+              [lexeme (in-option (lex-line line))])
+    (if (path? lexeme)
+        (values files lexeme)
+        (values (hash-update files current-file (range-set-add _ lexeme) empty-lines)
+                current-file))))
+
+
+(define (lex-line line)
+  (define file-match (regexp-match #px"^\\+\\+\\+ b/(.*)$" line))
+  (define single-line-match (regexp-match #px"^@@ .* \\+(\\d+) @@$" line))
+  (define range-match (regexp-match #px"^@@ .* \\+(\\d+),(\\d+) @@$" line))
+  (cond
+    [file-match
+     (match-define (list _ f) file-match)
+     (present (simplify-path f))]
+    [single-line-match
+     (match-define (list _ l) single-line-match)
+     (let ([l (string->number l)])
+       (present (closed-open-range l (add1 l) #:comparator natural<=>)))]
+    [range-match
+     (match-define (list _ l s) range-match)
+     (let ([l (string->number l)]
+           [s (string->number s)])
+       (if (equal? s 0)
+           absent ;; TODO: fix range-set-add so that I can return an empty range here
+           (present (closed-open-range l (+ l s) #:comparator natural<=>))))]
+    [else
+     (raise-argument-error
+      'lex-line
+      "a git file name line (starting with '+++ b/') or a hunk range line (starting with '@@')"
+      line)]))

--- a/private/linemap.rkt
+++ b/private/linemap.rkt
@@ -14,11 +14,13 @@
   [linemap-position-to-start-of-line (-> linemap? exact-positive-integer? exact-positive-integer?)]
   [linemap-position-to-end-of-line (-> linemap? exact-positive-integer? exact-positive-integer?)]
   [syntax-start-line-position (-> syntax? #:linemap linemap? exact-positive-integer?)]
-  [syntax-end-line-position (-> syntax? #:linemap linemap? exact-positive-integer?)]))
+  [syntax-end-line-position (-> syntax? #:linemap linemap? exact-positive-integer?)]
+  [syntax-line-range (-> syntax? #:linemap linemap? range?)]))
 
 
 (require rebellion/base/comparator
          rebellion/base/option
+         rebellion/base/range
          rebellion/collection/entry
          rebellion/collection/sorted-map
          rebellion/collection/vector/builder
@@ -93,6 +95,11 @@
 
 (define (syntax-end-line-position stx #:linemap map)
   (linemap-position-to-end-of-line map (+ (syntax-position stx) (syntax-span stx))))
+
+
+(define (syntax-line-range stx #:linemap map)
+  (define end-line (linemap-position-to-line map (+ (syntax-position stx) (syntax-span stx))))
+  (closed-range (syntax-line stx) end-line #:comparator natural<=>))
 
 
 (module+ test

--- a/private/source.rkt
+++ b/private/source.rkt
@@ -11,7 +11,7 @@
   [source-directory (-> source? (or/c path? #false))]
   [source-read-syntax (-> source? syntax?)]
   [source-produced-syntax? (-> source? syntax? boolean?)]
-  [source-analyze (-> source? #:lines range-set? source-code-analysis?)]
+  [source-analyze (->* (source?) (#:lines range-set?) source-code-analysis?)]
   [file-source? predicate/c]
   [file-source (-> path-string? file-source?)]
   [file-source-path (-> file-source? path?)]
@@ -33,6 +33,7 @@
          racket/port
          rebellion/base/comparator
          rebellion/base/immutable-string
+         rebellion/base/range
          rebellion/collection/list
          rebellion/collection/range-set
          rebellion/private/guarded-block
@@ -93,7 +94,7 @@
   (path-only path))
 
 
-(define (source-analyze code #:lines lines)
+(define (source-analyze code #:lines [lines (range-set (unbounded-range #:comparator natural<=>))])
   (parameterize ([current-directory (or (source-directory code) (current-directory))])
     (define code-linemap (string-linemap (source->string code)))
     (define stx (source-read-syntax code))


### PR DESCRIPTION
GitHub pull request reviews can only leave comments on lines the pull request modified. To support that, this PR changes Resyntax's `--local-git-repository` mode to only analyze the lines that were changed in the given git ref. Other lines in modified files are ignored.