### PR TITLE
Don't replace syntax when output has shadowed ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 compiled/
 doc/
+*~

--- a/default-recommendations/conditional-shortcuts-test.rkt
+++ b/default-recommendations/conditional-shortcuts-test.rkt
@@ -267,3 +267,9 @@ test: "cond with nested cond in last clause without else can't be flattened"
        [else
         (displayln "else")])]))
 ------------------------------
+
+test: "`if-else-false-to-and` is not refactorable when `and` is shadowed"
+------------------------------
+(define (and x y) (list x y))
+(if 'a (println "true branch") #f)
+------------------------------

--- a/default-recommendations/let-binding-suggestions-test.rkt
+++ b/default-recommendations/let-binding-suggestions-test.rkt
@@ -398,3 +398,24 @@ test: "let-values expressions with an immediate call are refactorable to call-wi
 
 test: "let-values expressions with an immediate call with different order aren't refactorable"
 - (let-values ([(x y z) (values 1 2 3)]) (list z y x))
+
+
+test: "let binding with conflicting define inside"
+------------------------------
+(define (g)
+  (let ([x 'outer])
+    (define x 'inner)
+    x))
+------------------------------
+
+
+test: "let binding with obfuscated conflicting define inside"
+------------------------------
+(define (g)
+  (let ([x 'outer])
+    (define-syntax-rule (m a)
+      (begin
+        (define a 'inner)
+        x))
+    (m x)))
+------------------------------

--- a/default-recommendations/private/let-binding.rkt
+++ b/default-recommendations/private/let-binding.rkt
@@ -441,7 +441,7 @@
 (define-splicing-syntax-class body-forms
   #:attributes (scopes [bound-id 1] [formatted 1])
   (pattern (~seq form:body-form ...)
-    #:with scopes (or (for/first ([b (in-list (reverse (attribute form)))])
+    #:with scopes (or (for/or ([b (in-list (reverse (attribute form)))])
                         (get-scopes-by-location b))
                       (and (pair? (attribute form)) (last (attribute form))))
     #:with (bound-id ...) #'(form.bound-id ... ...)

--- a/default-recommendations/private/let-binding.rkt
+++ b/default-recommendations/private/let-binding.rkt
@@ -243,7 +243,7 @@
 
 (define (no-binding-conflicts? ids body-scopes)
   (for/and ([x (in-list ids)])
-    (free-identifier=? (or (scopes-by-location x) x)
+    (free-identifier=? (or (get-scopes-by-location x) x)
                        (datum->syntax body-scopes (syntax-e x)))))
 
 
@@ -442,7 +442,7 @@
   #:attributes (scopes [bound-id 1] [formatted 1])
   (pattern (~seq form:body-form ...)
     #:with scopes (or (for/first ([b (in-list (reverse (attribute form)))])
-                        (scopes-by-location b))
+                        (get-scopes-by-location b))
                       (and (pair? (attribute form)) (last (attribute form))))
     #:with (bound-id ...) #'(form.bound-id ... ...)
     #:with (formatted ...) #'((~@ NEWLINE form) ...)))

--- a/default-recommendations/shadowed-output-test.rkt
+++ b/default-recommendations/shadowed-output-test.rkt
@@ -312,3 +312,46 @@ test: "shadowed `define-syntax-rule`: single-clause syntax-rules macro"
      (let ([tmp a])
        (if a a b))]))
 ------------------------------
+
+
+test: "shadowed `define-syntax-rule` using `define-syntax-parse-rule` after"
+------------------------------
+(define-syntax my-or
+  (syntax-rules ()
+    [(my-or a b)
+     (let ([tmp a])
+       (if a a b))]))
+(begin
+  (define-syntax-parse-rule (define-syntax-rule new old)
+    (define-syntax-parse-rule (new . args) (old . args)))
+  (define-syntax-rule def define)
+  (def x 5)
+  x)
+------------------------------
+
+
+test: "`define-syntax-rule` isn't actually shadowed in this scope"
+------------------------------
+(define-syntax my-or
+  (syntax-rules ()
+    [(my-or a b)
+     (let ([tmp a])
+       (if a a b))]))
+(let ()
+  (define-syntax-parse-rule (define-syntax-rule new old)
+    (define-syntax-parse-rule (new . args) (old . args)))
+  (define-syntax-rule def define)
+  (def x 5)
+  x)
+------------------------------
+------------------------------
+(define-syntax-rule (my-or a b)
+  (let ([tmp a])
+    (if a a b)))
+(let ()
+  (define-syntax-parse-rule (define-syntax-rule new old)
+    (define-syntax-parse-rule (new . args) (old . args)))
+  (define-syntax-rule def define)
+  (def x 5)
+  x)
+------------------------------

--- a/default-recommendations/shadowed-output-test.rkt
+++ b/default-recommendations/shadowed-output-test.rkt
@@ -1,0 +1,314 @@
+#lang resyntax/testing/refactoring-test
+
+
+require: resyntax/default-recommendations default-recommendations
+
+
+header:
+------------------------------
+#lang racket/base
+(require racket/list racket/match syntax/parse/define)
+------------------------------
+
+
+test: "shadowed `or`: single-line de morgan's law"
+------------------------------
+(define (or x y z) (append x y z))
+(and (not 1) (not 2) (not 3))
+------------------------------
+
+
+test: "shadowed `or`: multi-line de morgan's law"
+------------------------------
+(define (or x y z) (append x y z))
+(and (not 1)
+     (not 2)
+     (not 3))
+------------------------------
+
+
+test: "shadowed `and`: single-line de morgan's law"
+------------------------------
+(define (and x y z) (list x y z))
+(or (not 1) (not 2) (not 3))
+------------------------------
+
+
+test: "shadowed `and`: multi-line de morgan's law"
+------------------------------
+(define (and x y z) (list x y z))
+(or (not 1)
+    (not 2)
+    (not 3))
+------------------------------
+
+
+test: "shadowed `not`: if then false else true"
+------------------------------
+(define (not b) (list 'not b))
+(if 4 #false #true)
+------------------------------
+
+
+test: "shadowed `unless`: when not"
+------------------------------
+(define (unless c b) b)
+(when (not 'foo)
+  (displayln "not foo"))
+------------------------------
+
+
+test: "shadowed `displayln`: when not -> unless is fine"
+------------------------------
+(define (displayln s) s)
+(when (not 'foo)
+  (displayln "not foo"))
+------------------------------
+------------------------------
+(define (displayln s) s)
+(unless 'foo
+  (displayln "not foo"))
+------------------------------
+
+
+test: "shadowed `when`: unless not"
+------------------------------
+(define (when c b) b)
+(unless (not 'foo)
+  (displayln "foo"))
+------------------------------
+
+
+test: "shadowed `displayln`: unless not -> when is fine"
+------------------------------
+(define (displayln s) s)
+(unless (not 'foo)
+  (displayln "foo"))
+------------------------------
+------------------------------
+(define (displayln s) s)
+(when 'foo
+  (displayln "foo"))
+------------------------------
+
+
+test: "shadowed `and`: single-line if-else-false-to-and"
+------------------------------
+(define (and x y) (list x y))
+(if 'a (println "true branch") #f)
+------------------------------
+
+
+test: "shadowed `and`: multi-line if-else-false-to-and"
+------------------------------
+(define (and x y) (list x y))
+(if 'a
+    (println "true branch")
+    #f)
+------------------------------
+
+
+test: "shadowed `println`: single-line if-else-false-to-and is fine"
+------------------------------
+(define (println v) v)
+(if 'a (println "true branch") #f)
+------------------------------
+------------------------------
+(define (println v) v)
+(and 'a (println "true branch"))
+------------------------------
+
+
+test: "shadowed `println`: multi-line if-else-false-to-and is fine"
+------------------------------
+(define (println v) v)
+(if 'a
+    (println "true branch")
+    #f)
+------------------------------
+------------------------------
+(define (println v) v)
+(and 'a
+     (println "true branch"))
+------------------------------
+
+
+test: "shadowed `for`: for-each with long single-form body"
+------------------------------
+(define (for lst f) (for-each f lst))
+(define some-list (list 1 2 3))
+(for-each
+ (λ (a-very-very-very-long-variable-name-thats-so-very-long)
+   (displayln a-very-very-very-long-variable-name-thats-so-very-long))
+ some-list)
+------------------------------
+
+
+test: "shadowed `for`: for-each with multiple body forms"
+------------------------------
+(define (for lst f) (for-each f lst))
+(define some-list (list 1 2 3))
+(for-each
+ (λ (x)
+   (displayln x)
+   (displayln x))
+ some-list)
+------------------------------
+
+
+test: "shadowed `for/vector`: list->vector with for/list"
+------------------------------
+(define (for/vector f v) (list->vector (map f (vector->list v))))
+(list->vector
+ (for/list ([x (in-range 0 10)])
+   (displayln x)
+   (* x x)))
+------------------------------
+
+
+test: "shadowed `for*`: nested for forms"
+------------------------------
+(define (for* lsts f)
+  (for-each (λ (args) (apply f args)) (apply cartesian-product lsts)))
+(for ([x (in-range 0 5)])
+  (for ([y (in-range 0 5)])
+    (for ([z (in-range 0 5)])
+      (displayln x)
+      (displayln y)
+      (displayln z))))
+------------------------------
+
+
+test: "shadowed `for/first`: let loop over vector"
+------------------------------------------------------------
+(define (for/first lst f) (f (first lst)))
+(define vec (vector 0 1 2 3 4 5))
+(let loop ([i 0])
+  (and (< i (vector-length vec))
+       (let ([x (vector-ref vec i)])
+         (if (> x 3)
+             (+ x 42)
+             (loop (add1 i))))))
+------------------------------------------------------------
+
+
+test: "shadowed `for*`: for-each and append-map"
+------------------------------------------------------------
+(define (for* lsts f)
+  (for-each (λ (args) (apply f args)) (apply cartesian-product lsts)))
+(define words (list 'the 'quick 'brown 'fox))
+(for-each (λ (c)
+            (printf "Letter: ~a\n" c)
+            (printf "Letter code: ~a\n\n" (char->integer c)))
+          (append-map (λ (word) (string->list (symbol->string word)))
+                      words))
+------------------------------------------------------------
+
+
+test: "shadowed `struct`: define-struct without options"
+----------------------------------------
+(define (struct name n)
+  (define-values (struct:name _1 _2 _3 _4) (make-struct-type name #f n 0))
+  struct:name)
+(define-struct point (x y))
+----------------------------------------
+
+
+test: "shadowed `define`: let forms inside for loop bodies"
+------------------------------
+(define-values (definitions) (make-hasheq))
+(define-values (define)
+  (lambda (name value) (hash-set! definitions name value)))
+(for ([i (in-range 0 10)])
+  (let ([x 1])
+    (void)))
+------------------------------
+
+
+test: "shadowed `call-with-values`: let-values expressions with an immediate call"
+------------------------------
+(define (call-with-values generator receiver)
+  ((compose receiver generator)))
+(let-values ([(x y z) (values 1 2 3)]) (list x y z))
+------------------------------
+
+
+test: "shadowed `last`: first reverse of list"
+------------------------------
+(define (last l) (apply max l))
+(first (reverse (list 1 2 3)))
+------------------------------
+
+
+test: "shadowed `append-map`: (append* (map ...))"
+------------------------------
+(define ((append-map f) lst) (append* (map f lst)))
+(define (f x) (list x x x))
+(append* (map f (list 1 2 3)))
+------------------------------
+
+
+test: "shadowed `match-define`: single-clause match expressions"
+------------------------------
+(define-syntax-rule (match-define head clause ...)
+  (define/match head clause ...))
+(define (foo x)
+  (match x
+    [(list a b c)
+     (displayln "foo!")
+     (+ a b c)]))
+------------------------------
+
+
+test: "shadowed `add1`: lambda equivalent to add1"
+------------------------------
+(define (add1 v) (cons 1 v))
+(map (λ (x) (+ x 1)) (list 1 2 3))
+------------------------------
+
+
+test: "shadowed `sub1`: lambda equivalent to sub1"
+------------------------------
+(define (sub1 v) (rest v))
+(map (λ (x) (- x 1)) (list 1 2 3))
+------------------------------
+
+
+test: "shadowed `positive?`: lambda equivalent to positive?"
+------------------------------
+(define (positive? v) (and (cons? v) (= 1 (first v))))
+(filter (λ (x) (< 0 x)) (list -2 -1 0 1 2))
+------------------------------
+
+
+test: "shadowed `negative?`: lambda equivalent to negative?"
+------------------------------
+(define (negative? v) (and (cons? v) (= -1 (first v))))
+(filter (λ (x) (< x 0)) (list -2 -1 0 1 2))
+------------------------------
+
+
+test: "shadowed `define-syntax-parse-rule`: define-simple-macro"
+------------------------------
+(define-syntax-rule (define-syntax-parse-rule new old)
+  (define-simple-macro (new . args) (old . args)))
+(define-simple-macro (my-or a:expr b:expr)
+  (let ([tmp a])
+    (if a a b)))
+------------------------------
+
+
+test: "shadowed `define-syntax-rule`: single-clause syntax-rules macro"
+------------------------------
+(define-syntax define-syntax-rule
+  (syntax-rules ()
+    [(define-syntax-rule new old)
+     (define-syntax new
+       (syntax-rules ()
+         [(new . args) (old . args)]))]))
+(define-syntax my-or
+  (syntax-rules ()
+    [(my-or a b)
+     (let ([tmp a])
+       (if a a b))]))
+------------------------------

--- a/main.rkt
+++ b/main.rkt
@@ -78,10 +78,12 @@
   (define comments (with-input-from-string code-string read-comment-locations))
   (parameterize ([current-namespace (make-base-namespace)])
     (define analysis (source-analyze source))
-    (transduce
-     (source-code-analysis-visited-forms analysis)
-     (append-mapping (λ (stx) (in-option (refactoring-rules-refactor rule-list stx source comments))))
-     #:into into-list)))
+    (parameterize ([current-scopes-by-location
+                    (source-code-analysis-scopes-by-location analysis)])
+      (transduce
+       (source-code-analysis-visited-forms analysis)
+       (append-mapping (λ (stx) (in-option (refactoring-rules-refactor rule-list stx source comments))))
+       #:into into-list))))
 
 
 (define (refactor-file path-string #:suite [suite default-recommendations])

--- a/main.rkt
+++ b/main.rkt
@@ -56,7 +56,9 @@
             (raise (exn:fail:refactoring message (current-continuation-marks) rule syntax e)))])
       (option-map
        (option-filter
-        (refactoring-rule-refactor rule syntax)
+        (option-filter
+         (refactoring-rule-refactor rule syntax)
+         syntax-replacement-preserves-free-identifiers?)
         (syntax-replacement-preserves-comments? _ comments))
        (refactoring-result
         #:source source

--- a/refactoring-rule.rkt
+++ b/refactoring-rule.rkt
@@ -40,7 +40,9 @@
    ((refactoring-rule-transformer rule) (rule-introduction-scope syntax))
    (λ (new-syntax)
      (syntax-replacement
-      #:original-syntax syntax #:new-syntax (rule-introduction-scope new-syntax)))))
+      #:original-syntax syntax
+      #:new-syntax (rule-introduction-scope new-syntax)
+      #:introduction-scope rule-introduction-scope))))
 
 
 (define-simple-macro


### PR DESCRIPTION
```racket
#lang racket/base

(define (and x y) (list x y))

(define (member? e l)
  (if (member e l)
      #t
      #f))
```
should not be refactored to `(and (member e l) #t)` because `and` is shadowed.