### PR TITLE
Recommend `headers-assq*` over `headers-assq`.

### DIFF
--- a/default-recommendations.rkt
+++ b/default-recommendations.rkt
@@ -22,7 +22,8 @@
                resyntax/default-recommendations/numeric-shortcuts
                resyntax/default-recommendations/syntax-shortcuts
                resyntax/default-recommendations/syntax-parse-shortcuts
-               resyntax/default-recommendations/syntax-rules-shortcuts)
+               resyntax/default-recommendations/syntax-rules-shortcuts
+               resyntax/default-recommendations/web-server-recommendations)
  (contract-out
   [default-recommendations refactoring-suite?]))
 
@@ -46,6 +47,7 @@
          resyntax/default-recommendations/syntax-shortcuts
          resyntax/default-recommendations/syntax-parse-shortcuts
          resyntax/default-recommendations/syntax-rules-shortcuts
+         resyntax/default-recommendations/web-server-recommendations
          resyntax/refactoring-suite)
 
 
@@ -76,4 +78,5 @@
            (refactoring-suite-rules numeric-shortcuts)
            (refactoring-suite-rules syntax-shortcuts)
            (refactoring-suite-rules syntax-parse-shortcuts)
-           (refactoring-suite-rules syntax-rules-shortcuts))))
+           (refactoring-suite-rules syntax-rules-shortcuts)
+           (refactoring-suite-rules web-server-recommendations))))

--- a/default-recommendations/web-server-recommendations-test.rkt
+++ b/default-recommendations/web-server-recommendations-test.rkt
@@ -1,0 +1,21 @@
+#lang resyntax/testing/refactoring-test
+
+
+require: resyntax/default-recommendations web-server-recommendations
+
+
+header:
+------------------------------------------------------------------------------------------------------
+#lang racket/base
+(require web-server/http/request-structs)
+------------------------------------------------------------------------------------------------------
+
+
+test: "headers-assq is replaced with headers-assq*"
+- (headers-assq #"Cache-Control" '())
+- (headers-assq* #"Cache-Control" '())
+
+
+test: "higher-order headers-assq is replaced with headers-assq*"
+- (map headers-assq (list #"Cache-Control") (list '()))
+- (map headers-assq* (list #"Cache-Control") (list '()))

--- a/default-recommendations/web-server-recommendations.rkt
+++ b/default-recommendations/web-server-recommendations.rkt
@@ -1,0 +1,35 @@
+#lang racket/base
+
+
+(require racket/contract/base)
+
+
+(provide
+ (contract-out
+  [web-server-recommendations refactoring-suite?]))
+
+
+(require rebellion/private/static-name
+         resyntax/refactoring-rule
+         resyntax/refactoring-suite
+         resyntax/private/syntax-replacement
+         syntax/parse
+         syntax/parse/define
+         web-server/http/request-structs)
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(define-refactoring-rule headers-assq-to-headers-assq*
+  #:description "The `headers-assq` function is case-sensitive, which violates HTTP specifications.\
+ Use `headers-assq*` instead."
+  #:literals (headers-assq)
+  [headers-assq headers-assq*])
+
+
+(define web-server-recommendations
+  (refactoring-suite
+   #:name (name web-server-recommendations)
+   #:rules
+   (list headers-assq-to-headers-assq*)))


### PR DESCRIPTION
This required adjusting the core expansion observation code to make a note of visited identifiers. That way the `headers-assq-to-headers-assq*` rule can fire on uses of just the `headers-assq` identifier, regardless of surrounding context.