### PR TITLE
Fix git hunk header message parsing

### DIFF
--- a/private/git.rkt
+++ b/private/git.rkt
@@ -42,8 +42,8 @@
 
 (define (lex-line line)
   (define file-match (regexp-match #px"^\\+\\+\\+ b/(.*)$" line))
-  (define single-line-match (regexp-match #px"^@@ .* \\+(\\d+) @@$" line))
-  (define range-match (regexp-match #px"^@@ .* \\+(\\d+),(\\d+) @@$" line))
+  (define single-line-match (regexp-match #px"^@@ .* \\+(\\d+) @@" line))
+  (define range-match (regexp-match #px"^@@ .* \\+(\\d+),(\\d+) @@" line))
   (cond
     [file-match
      (match-define (list _ f) file-match)


### PR DESCRIPTION
Hunk headers can sometimes include the name of the function the hunk is part of, like `@@ -29,0 +30,10 @@ foo`.