### PR TITLE
Don't use `define` function shorthand in classes

### DIFF
--- a/default-recommendations/function-definition-shortcuts-test.rkt
+++ b/default-recommendations/function-definition-shortcuts-test.rkt
@@ -65,6 +65,16 @@ test: "lambda variable definition with rest argument to function definition"
 ------------------------------
 
 
+test: "class lambda variable definition not refactorable"
+------------------------------
+(require racket/class)
+(class object%
+  (define f
+    (λ (a b c)
+      1)))
+------------------------------
+
+
 test: "lambda function definition to function definition"
 ------------------------------
 (define (f a b c)

--- a/default-recommendations/function-definition-shortcuts.rkt
+++ b/default-recommendations/function-definition-shortcuts.rkt
@@ -78,6 +78,7 @@
  functions)."
   #:literals (define)
   [(define header lambda-form:possibly-nested-lambdas)
+   #:when (not (syntax-property this-syntax 'class-body))
    #:do [(define multiline-lambda-header-count
            (count multiline-syntax? (attribute lambda-form.original-formals)))]
    #:when (< multiline-lambda-header-count 2)


### PR DESCRIPTION
Closes #186. This won't work until https://github.com/racket/racket/pull/4620 is submitted.