### PR TITLE
Fix a bug in diff analysis

### DIFF
--- a/private/source.rkt
+++ b/private/source.rkt
@@ -105,7 +105,7 @@
     (define (add-original-location! hsh stx)
       (when (and (syntax? stx)
                  (syntax-original? stx)
-                 (range-set-intersects? lines (syntax-line-range stx #:linemap code-linemap)))
+                 (range-set-encloses? lines (syntax-line-range stx #:linemap code-linemap)))
         (define loc (syntax-source-location stx))
         (unless (hash-has-key? hsh loc)
           (hash-set! hsh loc stx))))


### PR DESCRIPTION
The current logic is buggy and fails for changes like [this](https://github.com/jackfirth/yaragg/pull/5). The correct behavior is for Resyntax to make sure that all of the changed lines in a suggestion are included in the set of lines changed by a pull request, rather than merely checking that these two sets intersect.