### PR TITLE
Remove predicate/c

### DIFF
--- a/default-recommendations/contract-shortcuts-test.rkt
+++ b/default-recommendations/contract-shortcuts-test.rkt
@@ -73,11 +73,6 @@ test: "nested and/c contracts interspersed with or/c contracts can be flattened"
 - (void (and/c 1 2 (or/c 3 4) 5 6))
 
 
-test: "contracts equivalent to predicate/c can be refactored to predicate/c"
-- (void (-> any/c boolean?))
-- (void predicate/c)
-
-
 test: "contracts equivalent to path-string? can be refactored to path-string?"
 - (void (or/c path? string?))
 - (void (or/c string? path?))

--- a/default-recommendations/contract-shortcuts.rkt
+++ b/default-recommendations/contract-shortcuts.rkt
@@ -44,13 +44,6 @@
    (and/c and-tree.leaf ...)])
 
 
-(define-refactoring-rule explicit-predicate/c-to-predicate/c
-  #:description "This contract is equivalent to the `predicate/c` contract."
-  #:literals (-> any/c boolean?)
-  [(-> any/c boolean?)
-   predicate/c])
-
-
 (define-refactoring-rule explicit-path-string?-to-path-string?
   #:description "This contract is equivalent to the `path-string?` predicate."
   #:literals (or/c path? string?)
@@ -78,6 +71,5 @@
    #:rules
    (list arrow-contract-with-rest-to-arrow-contract-with-ellipses
          explicit-path-string?-to-path-string?
-         explicit-predicate/c-to-predicate/c
          nested-or/c-to-flat-or/c
          nested-and/c-to-flat-and/c)))


### PR DESCRIPTION
Partially addresses #191. Can't fully resolve that issue yet since it requires Resyntax to allow rules to refactor usages of single identifiers, which doesn't currently seem to work.