### PR TITLE
Remove some dead code

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -19,8 +19,7 @@
         "fmt"
         "guard"
         "rackunit-lib"
-        "rebellion"
-        "uri-old"))
+        "rebellion"))
 
 
 (define build-deps


### PR DESCRIPTION
This used to be used in a previous iteration of the Resyntax and GitHub integration, but it isn't used anymore. Deleting it lets us get rid of the `uri-old` dependency. Fixes #225.