### PR TITLE
Add debug logs and display them in tests

### DIFF
--- a/private/logger.rkt
+++ b/private/logger.rkt
@@ -1,0 +1,12 @@
+#lang racket/base
+
+
+(provide log-resyntax-fatal
+         log-resyntax-error
+         log-resyntax-warning
+         log-resyntax-info
+         log-resyntax-debug
+         resyntax-logger)
+
+
+(define-logger resyntax)


### PR DESCRIPTION
This makes test failures caused by unexpectedly discarded suggestions much easier to diagnose. In the future I might expose a CLI switch to show these messages too, but for now just surfacing them in test failures is enough.