### PR TITLE
Delete `ORIGINAL-SPLICE`

### DIFF
--- a/default-recommendations/boolean-shortcuts.rkt
+++ b/default-recommendations/boolean-shortcuts.rkt
@@ -64,25 +64,21 @@
   #:description "This `if` expression can be refactored to an equivalent expression using `and`."
   #:literals (if)
   [(if condition then #false)
-   (and (ORIGINAL-SPLICE condition then))])
+   (and condition then)])
 
 
 (define-refactoring-rule inverted-when
   #:description "This negated when expression can be replaced by an unless expression."
   #:literals (when not)
-  [(when (~and negated (not condition))
-     body0 body ...)
-   (unless condition (ORIGINAL-GAP negated body0)
-     (ORIGINAL-SPLICE body0 body ...))])
+  [(when (~and negated (not condition)) body0 body ...)
+   (unless condition (ORIGINAL-GAP negated body0) body0 body ...)])
 
 
 (define-refactoring-rule inverted-unless
   #:description "This negated `unless` expression can be replaced by a `when` expression."
   #:literals (unless not)
-  [(unless (~and negated (not condition))
-     body0 body ...)
-   (when condition (ORIGINAL-GAP negated body0)
-     (ORIGINAL-SPLICE body0 body ...))])
+  [(unless (~and negated (not condition)) body0 body ...)
+   (when condition (ORIGINAL-GAP negated body0) body0 body ...)])
 
 
 (define boolean-shortcuts

--- a/default-recommendations/conditional-shortcuts.rkt
+++ b/default-recommendations/conditional-shortcuts.rkt
@@ -56,7 +56,7 @@
   #:description equivalent-conditional-description
   #:literals (if)
   [(if condition then-branch #false)
-   (and (ORIGINAL-SPLICE condition then-branch))])
+   (and condition then-branch)])
 
 
 (define-refactoring-rule if-x-else-x-to-and
@@ -64,7 +64,7 @@
   #:literals (if)
   [(if x:id then-branch:expr y:id)
    #:when (free-identifier=? #'x #'y)
-   (and (ORIGINAL-SPLICE x then-branch))])
+   (and x then-branch)])
 
 
 (define-syntax-class block-expression
@@ -89,7 +89,7 @@
   #:description equivalent-conditional-description
   [conditional:when-or-unless-equivalent-conditional
    ((~if conditional.negated? unless when)
-    conditional.condition (ORIGINAL-SPLICE conditional.body ...))])
+    conditional.condition conditional.body ...)])
 
 
 (define-refactoring-rule always-throwing-if-to-when
@@ -119,7 +119,7 @@
    (header.formatted
     ...
     ((~if condition.negated? unless when) condition.base-condition fail)
-    (ORIGINAL-SPLICE body ...))])
+    body ...)])
 
 
 (define-refactoring-rule cond-else-cond-to-cond
@@ -129,9 +129,9 @@
   [((~and outer-cond-id cond)
     clause ... last-non-else-clause
     (~and outer-else-clause [else (cond nested-clause ...)]))
-   ((ORIGINAL-SPLICE outer-cond-id clause ... last-non-else-clause)
+   (outer-cond-id clause ... last-non-else-clause
     (ORIGINAL-GAP last-non-else-clause outer-else-clause)
-    (ORIGINAL-SPLICE nested-clause ...))])
+    nested-clause ...)])
 
 
 (define-syntax-class let-refactorable-cond-clause
@@ -163,9 +163,9 @@
    #:with (after ...)
    (let ([form-after (first-syntax #'(clause-after ...))])
      (if form-after
-         #`((ORIGINAL-GAP clause #,form-after) (ORIGINAL-SPLICE clause-after ...))
+         #`((ORIGINAL-GAP clause #,form-after) clause-after ...)
          (list)))
-   ((ORIGINAL-SPLICE outer-cond-id clause-before ...)
+   (outer-cond-id clause-before ...
     (ORIGINAL-GAP form-before clause)
     clause.refactored
     after ...)])
@@ -177,7 +177,7 @@
   (pattern (begin body ...)
     #:attr uses-begin? #true
     #:attr uses-let? #false
-    #:with (refactored ...) #'((ORIGINAL-SPLICE body ...)))
+    #:with (refactored ...) #'(body ...))
   (pattern :refactorable-let-expression
     #:attr uses-begin? #false
     #:attr uses-let? #true)

--- a/default-recommendations/contract-shortcuts.rkt
+++ b/default-recommendations/contract-shortcuts.rkt
@@ -58,7 +58,7 @@
     (~and rest-kw #:rest) (~and rest-list (listof rest-contract))
     result-contract)
    (-> (ORIGINAL-GAP arrow-id args)
-       (ORIGINAL-SPLICE arg-contract ...)
+       arg-contract ...
        (ORIGINAL-GAP args rest-kw)
        rest-contract (... ...)
        (ORIGINAL-GAP rest-list result-contract)

--- a/default-recommendations/definition-shortcuts.rkt
+++ b/default-recommendations/definition-shortcuts.rkt
@@ -10,13 +10,10 @@
 
 
 (require (for-syntax racket/base)
-         racket/sequence
          rebellion/private/static-name
          resyntax/default-recommendations/private/definition-context
-         resyntax/default-recommendations/private/syntax-lines
          resyntax/refactoring-rule
          resyntax/refactoring-suite
-         resyntax/private/syntax-replacement
          syntax/parse)
 
 
@@ -32,7 +29,7 @@
     rest ...)
    (header.formatted ...
     (define id expr) ...
-    (ORIGINAL-SPLICE rest ...))])
+    rest ...)])
 
 
 (define definition-shortcuts

--- a/default-recommendations/function-shortcuts.rkt
+++ b/default-recommendations/function-shortcuts.rkt
@@ -62,7 +62,7 @@
   "The `apply` function accepts single arguments in addition to a trailing list argument."
   #:literals (apply)
   [((~and id apply) function:expr arg ... trailing-arg:trailing-list-argument)
-   ((ORIGINAL-SPLICE id function arg ...) trailing-arg.lifted ... trailing-arg.trailing)])
+   (id function arg ... trailing-arg.lifted ... trailing-arg.trailing)])
 
 
 (define function-shortcuts

--- a/default-recommendations/hash-shortcuts.rkt
+++ b/default-recommendations/hash-shortcuts.rkt
@@ -30,7 +30,7 @@
   #:description "The lambda can be removed from the failure result in this `hash-ref` expression."
   #:literals (hash-ref)
   [((~and ref hash-ref) h:expr k:expr (~and lambda-expr (_:lambda-by-any-name () v:literal-constant)))
-   ((ORIGINAL-SPLICE ref h k) (ORIGINAL-GAP k lambda-expr) v)])
+   (ref h k (ORIGINAL-GAP k lambda-expr) v)])
 
 
 (define-refactoring-rule hash-ref!-with-constant-lambda-to-hash-ref!-without-lambda
@@ -38,7 +38,7 @@
   #:literals (hash-ref!)
   [((~and ref hash-ref!) h:expr k:expr
                          (~and lambda-expr (_:lambda-by-any-name () v:literal-constant)))
-   ((ORIGINAL-SPLICE ref h k) (ORIGINAL-GAP k lambda-expr) v)])
+   (ref h k (ORIGINAL-GAP k lambda-expr) v)])
 
 
 (define-syntax-class value-initializer

--- a/default-recommendations/legacy-struct-migrations.rkt
+++ b/default-recommendations/legacy-struct-migrations.rkt
@@ -38,17 +38,16 @@
 
 
 (define-splicing-syntax-class struct-option
-  #:attributes (keyword [expr 1] [formatted 1] [original 1])
+  #:attributes (keyword [expr 1] [original 1])
   (pattern (~seq (~and keyword:keyword (~not :constructor-name-keyword)) expr:expr ...)
-    #:with (original ...) #'(keyword expr ...)
-    #:with (formatted ...) #'((ORIGINAL-SPLICE keyword expr ...))))
+    #:with (original ...) #'(keyword expr ...)))
 
 
 (define-refactoring-rule define-struct-to-struct
   #:description "The `define-struct` form exists for backwards compatibility, `struct` is preferred."
   #:literals (define-struct)
   [(define-struct id:id-maybe-super fields option:struct-option ...)
-   (struct id.migrated ... (ORIGINAL-SPLICE fields option.original ... ...)
+   (struct id.migrated ... fields option.original ... ...
      #:extra-constructor-name id.make-id)])
 
 

--- a/default-recommendations/legacy-syntax-migrations.rkt
+++ b/default-recommendations/legacy-syntax-migrations.rkt
@@ -27,36 +27,31 @@
 (define-refactoring-rule datum->syntax-migration
   #:description "The fifth argument to `datum->syntax` is ignored."
   #:literals (datum->syntax)
-  [((~and id datum->syntax) ctxt v srcloc prop ignored)
-   ((ORIGINAL-SPLICE id ctxt v srcloc prop))])
+  [((~and id datum->syntax) ctxt v srcloc prop ignored) (id ctxt v srcloc prop)])
 
 
 (define-refactoring-rule syntax-recertify-migration
   #:description "The `syntax-recertify` function is a legacy function that does nothing."
   #:literals (syntax-recertify)
-  [(syntax-recertify stx _ _ _)
-   stx])
+  [(syntax-recertify stx _ _ _) stx])
 
 
 (define-refactoring-rule syntax-disarm-migration
   #:description "The `syntax-disarm` function is a legacy function that does nothing."
   #:literals (syntax-disarm)
-  [(syntax-disarm stx _)
-   stx])
+  [(syntax-disarm stx _) stx])
 
 
 (define-refactoring-rule syntax-rearm-migration
   #:description "The `syntax-rearm` function is a legacy function that does nothing."
   #:literals (syntax-rearm)
-  [(syntax-rearm stx _ ...)
-   stx])
+  [(syntax-rearm stx _ ...) stx])
 
 
 (define-refactoring-rule syntax-protect-migration
   #:description "The `syntax-protect` function is a legacy function that does nothing."
   #:literals (syntax-protect)
-  [(syntax-protect stx)
-   stx])
+  [(syntax-protect stx) stx])
 
 
 (define-refactoring-rule syntax-local-match-introduce-migration

--- a/default-recommendations/let-binding-suggestions.rkt
+++ b/default-recommendations/let-binding-suggestions.rkt
@@ -52,7 +52,7 @@
   #:literals (let)
   [(let name:id header body ...)
    #:when (not (set-member? (syntax-free-identifiers #'(body ...)) #'name))
-   (let (ORIGINAL-SPLICE header body ...))])
+   (let header body ...)])
 
 
 (define-refactoring-rule let-values-then-call-to-call-with-values

--- a/default-recommendations/match-shortcuts.rkt
+++ b/default-recommendations/match-shortcuts.rkt
@@ -32,7 +32,7 @@
       [pattern body ...]))
    (header.formatted ...
     (match-define pattern subject)
-    (ORIGINAL-SPLICE body ...))])
+    body ...)])
 
 
 (define match-shortcuts

--- a/default-recommendations/private/definition-context.rkt
+++ b/default-recommendations/private/definition-context.rkt
@@ -99,7 +99,7 @@
     #:with (formatted ...) #'(let-values header))
 
   (pattern (~seq (~and id let*-values) ~! header)
-    #:with (formatted ...) #'((ORIGINAL-SPLICE id header)))
+    #:with (formatted ...) #'(id header))
 
   (pattern (~seq when ~! condition)
     #:with (formatted ...) #'(when condition))
@@ -140,7 +140,7 @@
                 for*/last))
      ~!
      clauses)
-    #:with (formatted ...) #'((ORIGINAL-SPLICE for-id clauses)))
+    #:with (formatted ...) #'(for-id clauses))
 
   (pattern
     (~seq
@@ -148,7 +148,7 @@
      ~!
      (~alt (~optional (~seq #:length length-expr)) (~optional (~seq #:fill fill-expr))) ...
      clauses)
-    #:with (formatted ...) #'((ORIGINAL-SPLICE for-id clauses))))
+    #:with (formatted ...) #'(for-id clauses)))
 
 
 ;; There's a lot of variants of define that support the same grammar but have different meanings. We

--- a/default-recommendations/private/let-binding.rkt
+++ b/default-recommendations/private/let-binding.rkt
@@ -290,7 +290,7 @@
           [else #`(define #,id #,rhs)])])]
     [_
      (cond
-       [different-lines? #`(define-values (ORIGINAL-SPLICE #,id-side #,rhs))]
+       [different-lines? #`(define-values #,id-side #,rhs)]
        [else #`(define-values #,id-side #,rhs)])]))
 
 

--- a/default-recommendations/string-shortcuts.rkt
+++ b/default-recommendations/string-shortcuts.rkt
@@ -29,14 +29,14 @@
 
 
 (define-syntax-class keywordless-string-join-call
-  #:attributes (original-splice)
+  #:attributes ([original 1])
   #:literals (string-join)
 
   (pattern ((~and id string-join) strs)
-    #:with original-splice #'(ORIGINAL-SPLICE id strs))
+    #:with (original ...) #'(id strs))
 
   (pattern ((~and id string-join) strs sep)
-    #:with original-splice #'(ORIGINAL-SPLICE id sep)))
+    #:with (original ...) #'(id sep)))
 
 
 (define-syntax-class string-append-and-string-join-expression
@@ -45,15 +45,15 @@
 
   (pattern (string-append before join-call:keywordless-string-join-call)
     #:with refactored
-    #'(join-call.original-splice (ORIGINAL-GAP before join-call) #:before-first before))
+    #'(join-call.original ... (ORIGINAL-GAP before join-call) #:before-first before))
 
   (pattern (string-append join-call:keywordless-string-join-call after)
     #:with refactored
-    #'(join-call.original-splice (ORIGINAL-GAP join-call after) #:after-last after))
+    #'(join-call.original ... (ORIGINAL-GAP join-call after) #:after-last after))
 
   (pattern (string-append before join-call:keywordless-string-join-call after)
     #:with refactored
-    #'(join-call.original-splice
+    #'(join-call.original ...
        (ORIGINAL-GAP before join-call) #:before-first before
        (ORIGINAL-GAP join-call after) #:after-last after)))
 

--- a/default-recommendations/syntax-parse-shortcuts.rkt
+++ b/default-recommendations/syntax-parse-shortcuts.rkt
@@ -31,7 +31,7 @@
    #:when (equal? (syntax-e #'original) 'define-simple-macro)
    
    (define-syntax-parse-rule (ORIGINAL-GAP original first-form)
-     (ORIGINAL-SPLICE first-form form ...))])
+     first-form form ...)])
 
 
 (define syntax-parse-shortcuts


### PR DESCRIPTION
The original splice inference system implemented in #243 makes it unnecessary.