### PR TITLE
Log broken refactoring attempts

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -54,8 +54,8 @@
     (with-handlers
         ([exn:fail?
           (λ (e)
-            (log-resyntax-warning "~a: refactoring attempt failed\n  syntax: ~e\n  cause: ~e"
-                                  (object-name rule) syntax e)
+            (log-resyntax-error "~a: refactoring attempt failed\n  syntax: ~e\n  cause: ~e"
+                                (object-name rule) syntax e)
             absent)])
       (guarded-block
         (guard-match (present replacement)

--- a/main.rkt
+++ b/main.rkt
@@ -54,10 +54,9 @@
     (with-handlers
         ([exn:fail?
           (λ (e)
-            (define message
-              (format "~a: refactoring attempt failed\n  syntax: ~e\n  cause: ~e"
-                      (object-name rule) syntax e))
-            (raise (exn:fail:refactoring message (current-continuation-marks) rule syntax e)))])
+            (log-resyntax-warning "~a: refactoring attempt failed\n  syntax: ~e\n  cause: ~e"
+                                  (object-name rule) syntax e)
+            absent)])
       (guarded-block
         (guard-match (present replacement)
           (refactoring-rule-refactor rule syntax #:analysis analysis)


### PR DESCRIPTION
This allows Resyntax to continue attempting to apply other refactoring rules when one rule breaks.