### PR TITLE
Add manual `string-join` refactoring

### DIFF
--- a/default-recommendations/hash-shortcuts-test.rkt
+++ b/default-recommendations/hash-shortcuts-test.rkt
@@ -54,7 +54,7 @@ test: "hash-ref! with non-constant lambda cannot be simplified to hash-ref! with
 ------------------------------
 
 
-test: "hash-ref with hash-set! lambda can be simplified to hash-ref!"
+test: "hash-ref with hash-set! can be simplified to hash-ref!"
 ------------------------------
 (define h (make-hash))
 (define k 'a)
@@ -66,17 +66,32 @@ test: "hash-ref with hash-set! lambda can be simplified to hash-ref!"
 ------------------------------
 (define h (make-hash))
 (define k 'a)
+(or (hash-ref h k #false)
+    (let ([v (+ 1 2 3)])
+      (hash-set! h k v)
+      v))
+------------------------------
+------------------------------
+(define h (make-hash))
+(define k 'a)
 (hash-ref! h k (λ () (+ 1 2 3)))
 ------------------------------
 
 
-test: "hash-ref with hash-set! lambda and literal keys can be simplified to hash-ref!"
+test: "hash-ref with hash-set! and literal keys can be simplified to hash-ref!"
 ------------------------------
 (define h (make-hash))
 (hash-ref h 'a (λ ()
                  (define v (+ 1 2 3))
                  (hash-set! h 'a v)
                  v))
+------------------------------
+------------------------------
+(define h (make-hash))
+(or (hash-ref h 'a #false)
+    (let ([v (+ 1 2 3)])
+      (hash-set! h 'a v)
+      v))
 ------------------------------
 ------------------------------
 (define h (make-hash))

--- a/default-recommendations/hash-shortcuts.rkt
+++ b/default-recommendations/hash-shortcuts.rkt
@@ -82,6 +82,20 @@
    (hash-ref! h1 k1 v1)])
 
 
+(define-refactoring-rule or-hash-ref-set!-to-hash-ref!
+  #:description "This expression can be replaced with a simpler, equivalent `hash-ref!` expression."
+  #:literals (or hash-ref hash-set! let)
+  [(or (hash-ref h1:id k1:pure-expression #false)
+       (let ([v1:id initializer:value-initializer])
+         (hash-set! h2:id k2:pure-expression v2:id)
+         v3:id))
+   #:when (free-identifier=? #'h1 #'h2)
+   #:when (syntax-free-identifier=? #'k1 #'k2)
+   #:when (free-identifier=? #'v1 #'v2)
+   #:when (free-identifier=? #'v1 #'v3)
+   (hash-ref! h1 k1 initializer.failure-result-form)])
+
+
 (define-refactoring-rule hash-set!-ref-to-hash-update!
   #:description
   "This expression can be replaced with a simpler, equivalent `hash-update!` expression."
@@ -124,4 +138,5 @@
                  hash-ref-set!-with-constant-to-hash-ref!
                  hash-ref-with-constant-lambda-to-hash-ref-without-lambda
                  hash-ref!-with-constant-lambda-to-hash-ref!-without-lambda
-                 hash-set!-ref-to-hash-update!)))
+                 hash-set!-ref-to-hash-update!
+                 or-hash-ref-set!-to-hash-ref!)))

--- a/default-recommendations/string-shortcuts-test.rkt
+++ b/default-recommendations/string-shortcuts-test.rkt
@@ -53,6 +53,17 @@ test: "string-append with only one string can be removed"
 - "hello"
 
 
+test: "manual string-join can be replaced with real string-join"
+------------------------------
+(require racket/list)
+(apply string-append (add-between (list "apple" "orange" "banana") ", "))
+------------------------------
+------------------------------
+(require racket/list)
+(string-join (list "apple" "orange" "banana") ", ")
+------------------------------
+
+
 test: "format with only one argument can be removed"
 - (format "hello")
 - "hello"

--- a/default-recommendations/string-shortcuts.rkt
+++ b/default-recommendations/string-shortcuts.rkt
@@ -9,14 +9,14 @@
   [string-shortcuts refactoring-suite?]))
 
 
-(require racket/set
+(require racket/list
+         racket/set
          racket/string
          rebellion/private/static-name
          resyntax/refactoring-rule
          resyntax/refactoring-suite
          resyntax/private/syntax-replacement
-         syntax/parse
-         syntax/parse/define)
+         syntax/parse)
 
 
 ;@----------------------------------------------------------------------------------------------------
@@ -71,6 +71,13 @@
   [(string-append s) s])
 
 
+(define-refactoring-rule manual-string-join
+  #:description "This use of `string-append` and `add-between` is equivalent to `string-join`."
+  #:literals (apply string-append add-between)
+  [(apply string-append (add-between strings separator))
+   (string-join strings separator)])
+
+
 (define formatting-directives
   (set "~n"
        "~%"
@@ -119,5 +126,6 @@
    #:rules
    (list display-newline-to-newline
          format-identity
+         manual-string-join
          string-append-and-string-join-to-string-join
          string-append-identity)))


### PR DESCRIPTION
Closes #246. Unfortunately, this only fires if the surrounding module is already importing `racket/string`.