### PR TITLE
Add `for/fold-result-keyword` rule.

### DIFF
--- a/default-recommendations/for-loop-shortcuts-test.rkt
+++ b/default-recommendations/for-loop-shortcuts-test.rkt
@@ -301,6 +301,30 @@ test: "for*/fold building hash can't be refactored when referring to hash"
 ------------------------------
 
 
+test: "multi-accumulator for/fold with one used result refactorable to for/fold using #:result"
+------------------------------
+(define (foo)
+  (define-values (x y z)
+    (for/fold ([accum1 0]
+               [accum2 0]
+               [accum3 0])
+              ([n (in-naturals)])
+      (values 0 0 0)))
+  (* x 2))
+------------------------------
+------------------------------
+(define (foo)
+  (define x
+    (for/fold ([accum1 0]
+               [accum2 0]
+               [accum3 0]
+               #:result accum1)
+              ([n (in-naturals)])
+      (values 0 0 0)))
+  (* x 2))
+------------------------------
+
+
 test: "list->vector with for/list to for/vector"
 ------------------------------
 (list->vector

--- a/main.rkt
+++ b/main.rkt
@@ -58,10 +58,13 @@
         (guard-match (present replacement)
           (refactoring-rule-refactor rule syntax #:analysis analysis)
           #:else absent)
-        (guard (syntax-replacement-preserves-free-identifiers? replacement) #:else
+        (guard (syntax-replacement-introduces-incorrect-bindings? replacement) #:else
           (log-resyntax-error
-           "~a: suggestion discarded because it does not preserve all free identifiers"
-           (object-name rule))
+           (string-append
+            "~a: suggestion discarded because it introduces identifiers with incorrect bindings\n"
+            "  incorrect identifiers: ~a")
+           (object-name rule)
+           (syntax-replacement-introduced-incorrect-identifiers replacement))
           absent)
         (guard (syntax-replacement-preserves-comments? replacement comments) #:else
           (log-resyntax-warning


### PR DESCRIPTION
Closes #215. This rule specifically only targets the case where `for/fold` is used with `define-values` and exactly one of the result values is used. That seems like the most common and easily fixable case.

Additionally, this change improves the logging for suggestions that have binding problems. Some names are also changed to make it clearer what's going on.