### PR TITLE
Add `~splicing-replacement` metafunction

### DIFF
--- a/default-recommendations/let-binding-suggestions-comment-test.rkt
+++ b/default-recommendations/let-binding-suggestions-comment-test.rkt
@@ -50,7 +50,24 @@ test: "let binding with commented first clause not refactorable (yet)"
 ------------------------------
 
 
-test: "let binding with commented body refactorable"
+test: "let binding with commented first body form refactorable"
+------------------------------
+(define (f)
+  (let ([x 1])
+    ;; Comment
+    (void)
+    1))
+------------------------------
+------------------------------
+(define (f)
+  (define x 1)
+  ;; Comment
+  (void)
+  1)
+------------------------------
+
+
+test: "let binding with commented second body form refactorable"
 ------------------------------
 (define (f)
   (let ([x 1])
@@ -67,7 +84,7 @@ test: "let binding with commented body refactorable"
 ------------------------------
 
 
-test: "let binding with comments before let form not refactorable (yet)"
+test: "let binding with comments before let form refactorable"
 ------------------------------
 (define (f)
   ;; Comment
@@ -75,4 +92,12 @@ test: "let binding with comments before let form not refactorable (yet)"
   ;; Comment
   (let ([x 1])
     1))
+------------------------------
+------------------------------
+(define (f)
+  ;; Comment
+  (void)
+  ;; Comment
+  (define x 1)
+  1)
 ------------------------------

--- a/private/syntax-replacement.rkt
+++ b/private/syntax-replacement.rkt
@@ -131,8 +131,7 @@
 
 (define/guard (original-separator-piece stx trailing-stx)
   (guard (syntax-originally-neighbors? stx trailing-stx) #:else #false)
-  (let* ([stx (syntax-extract-original stx)]
-         [trailing-stx (syntax-extract-original trailing-stx)])
+  (let-values ([(stx trailing-stx) (syntax-extract-originals-from-pair stx trailing-stx)])
     (define stx-end (+ (sub1 (syntax-position stx)) (syntax-span stx)))
     (define trailing-start (sub1 (syntax-position trailing-stx)))
     (copied-string stx-end trailing-start)))


### PR DESCRIPTION
The `~splicing-replacement` metafunction is similar to `~replacement`, but for the case when a sequence of multiple forms replaces a single form. This commit uses it in `let-to-define` and related rules to preserve more comments.