### PR TITLE
Replace `ORIGINAL-GAP` with `#:original-splice`

### DIFF
--- a/default-recommendations/conditional-shortcuts-test.rkt
+++ b/default-recommendations/conditional-shortcuts-test.rkt
@@ -332,17 +332,45 @@ test: "cond with nested else-cond can be flattened"
 ------------------------------
 
 
-test: "flattening nested else-cond does not preserve single-line formatting"
+test: "cond with commented nested else-cond can be flattened"
 ------------------------------
 (define (f a b)
-  (cond [a 1] [else (cond [b 2] [else 3])]))
+  (cond
+    [a (displayln "a")]
+    ; comment
+    [else
+     (cond
+       [b (displayln "b")]
+       [else (displayln "else")])]))
 ------------------------------
 ------------------------------
 (define (f a b)
   (cond
-    [a 1]
-    [b 2]
-    [else 3]))
+    [a (displayln "a")]
+    ; comment
+    [b (displayln "b")]
+    [else (displayln "else")]))
+------------------------------
+
+
+test: "cond with nested else-cond with commented second clause can be flattened"
+------------------------------
+(define (f a b)
+  (cond
+    [a (displayln "a")]
+    [else
+     (cond
+       [b (displayln "b")]
+       ; comment
+       [else (displayln "else")])]))
+------------------------------
+------------------------------
+(define (f a b)
+  (cond
+    [a (displayln "a")]
+    [b (displayln "b")]
+    ; comment
+    [else (displayln "else")]))
 ------------------------------
 
 
@@ -467,80 +495,6 @@ test: "if clause with begin in both branches refactorable to cond"
 ------------------------------
 
 
-test: "if clause with multiline condition and begin in true branch refactorable to cond"
-------------------------------
-(define (f a b c)
-  (if (a 10000000000000000000000000000000000000
-         20000000000000000000000000000000000000
-         30000000000000000000000000000000000000)
-      (begin
-        (displayln "stuff")
-        b)
-      c))
-------------------------------
-------------------------------
-(define (f a b c)
-  (cond
-    [(a 10000000000000000000000000000000000000
-        20000000000000000000000000000000000000
-        30000000000000000000000000000000000000)
-     (displayln "stuff")
-     b]
-    [else c]))
-------------------------------
-
-
-test: "if clause with multiline condition and begin in false branch refactorable to cond"
-------------------------------
-(define (f a b c)
-  (if (a 10000000000000000000000000000000000000
-         20000000000000000000000000000000000000
-         30000000000000000000000000000000000000)
-      b
-      (begin
-        (displayln "stuff")
-        c)))
-------------------------------
-------------------------------
-(define (f a b c)
-  (cond
-    [(a 10000000000000000000000000000000000000
-        20000000000000000000000000000000000000
-        30000000000000000000000000000000000000)
-     b]
-    [else
-     (displayln "stuff")
-     c]))
-------------------------------
-
-
-test: "if clause with multiline condition and begin in both branches refactorable to cond"
-------------------------------
-(define (f a b c)
-  (if (a 10000000000000000000000000000000000000
-         20000000000000000000000000000000000000
-         30000000000000000000000000000000000000)
-      (begin
-        (displayln "stuff")
-        b)
-      (begin
-        (displayln "stuff")
-        c)))
-------------------------------
-------------------------------
-(define (f a b c)
-  (cond
-    [(a 10000000000000000000000000000000000000
-        20000000000000000000000000000000000000
-        30000000000000000000000000000000000000)
-     (displayln "stuff")
-     b]
-    [else
-     (displayln "stuff")
-     c]))
-------------------------------
-
-
 test: "if clause with begin in commented true branch refactorable to cond"
 ------------------------------
 (define (f a b c)
@@ -576,8 +530,8 @@ test: "if clause with begin in commented false branch refactorable to cond"
 (define (f a b c)
   (cond
     [a b]
+    ;; This is the false case
     [else
-     ;; This is the false case
      (displayln "stuff")
      c]))
 ------------------------------
@@ -603,8 +557,8 @@ test: "if clause with begin in both commented branches refactorable to cond"
      ;; This is the true case
      (displayln "stuff")
      b]
+    ;; This is the false case
     [else
-     ;; This is the false case
      (displayln "stuff")
      c]))
 ------------------------------
@@ -813,8 +767,8 @@ test: "if clause with let in commented false branch refactorable to cond"
 (define (f a b c)
   (cond
     [a b]
+    ;; This is the false case
     [else
-     ;; This is the false case
      (define x 1)
      c]))
 ------------------------------
@@ -838,8 +792,8 @@ test: "if clause with let in both commented branches refactorable to cond"
      ;; This is the true case
      (define x 1)
      b]
+    ;; This is the false case
     [else
-     ;; This is the false case
      (define x 1)
      c]))
 ------------------------------

--- a/default-recommendations/function-definition-shortcuts-test.rkt
+++ b/default-recommendations/function-definition-shortcuts-test.rkt
@@ -97,20 +97,28 @@ test: "lambda function definition with closed-over expressions not refactorable"
 ------------------------------
 
 
-test: "lambda variable definition with commented body to definition with preserved comments"
+test: "lambda variable definition with commented first body not refactorable (yet)"
 ------------------------------
 (define f
   (λ (a)
-    ;; comment before all body forms
+    ; comment
     (void)
-    ;; comment before last body form
+    1))
+------------------------------
+
+
+test: "lambda variable definition with commented second body refactorable to definition"
+------------------------------
+(define f
+  (λ (a)
+    (void)
+    ; comment
     1))
 ------------------------------
 ------------------------------
 (define (f a)
-  ;; comment before all body forms
   (void)
-  ;; comment before last body form
+  ; comment
   1)
 ------------------------------
 

--- a/default-recommendations/function-definition-shortcuts.rkt
+++ b/default-recommendations/function-definition-shortcuts.rkt
@@ -51,8 +51,7 @@
      (~and initial-body (~not _:possibly-nested-lambdas))
      remaining-body ...)
     #:with (argument-lists ...) #'(first-argument-list)
-    #:with (body ...)
-    #'((ORIGINAL-GAP first-argument-list initial-body) initial-body remaining-body ...)))
+    #:with (body ...) #'(initial-body remaining-body ...)))
 
 
 (define/guard (build-function-header original-header converted-lambda-formal-lists)

--- a/default-recommendations/string-shortcuts.rkt
+++ b/default-recommendations/string-shortcuts.rkt
@@ -45,18 +45,13 @@
   #:literals (string-append)
 
   (pattern (string-append before join-call:keywordless-string-join-call)
-    #:with refactored
-    #'(join-call.original ... (ORIGINAL-GAP before join-call) #:before-first before))
+    #:with refactored #'(join-call.original ... #:before-first before))
 
   (pattern (string-append join-call:keywordless-string-join-call after)
-    #:with refactored
-    #'(join-call.original ... (ORIGINAL-GAP join-call after) #:after-last after))
+    #:with refactored #'(join-call.original ... #:after-last after))
 
   (pattern (string-append before join-call:keywordless-string-join-call after)
-    #:with refactored
-    #'(join-call.original ...
-       (ORIGINAL-GAP before join-call) #:before-first before
-       (ORIGINAL-GAP join-call after) #:after-last after)))
+    #:with refactored #'(join-call.original ... #:before-first before #:after-last after)))
 
 
 (define-refactoring-rule string-append-and-string-join-to-string-join

--- a/private/syntax-replacement.rkt
+++ b/private/syntax-replacement.rkt
@@ -5,7 +5,6 @@
 
 
 (provide
- ORIGINAL-GAP
  (contract-out
   [syntax-replacement? predicate/c]
   [syntax-replacement
@@ -49,14 +48,6 @@
 ;@----------------------------------------------------------------------------------------------------
 
 
-(define-syntax (ORIGINAL-GAP stx)
-  (raise-syntax-error
-   #false
-   "should only be used by refactoring rules to indicate where to insert the content between two\
- original syntax objects"
-   stx))
-
-
 (define-record-type syntax-replacement
   (original-syntax new-syntax introduction-scope))
 
@@ -69,13 +60,8 @@
       (define end (+ start (syntax-span stx)))
       (list (copied-string start end)))
     (syntax-parse stx
-      #:literals (quote ORIGINAL-GAP)
+      #:literals (quote)
 
-      [(ORIGINAL-GAP ~! before after)
-       (define before-end (+ (sub1 (syntax-position #'before)) (syntax-span #'before)))
-       (define after-start (sub1 (syntax-position #'after)))
-       (list (copied-string before-end after-start))]
-      
       [(~or v:id v:boolean v:char v:keyword v:number v:regexp v:byte-regexp v:string v:bytes)
        (list (inserted-string (string->immutable-string (~s (syntax-e #'v)))))]
       
@@ -185,9 +171,7 @@
                                     #:new-syntax new
                                     #:introduction-scope intro)
     replacement)
-  (define ignore (list #'ORIGINAL-GAP))
   (for/and ([new-id (in-syntax-identifiers new)]
-            #:unless (member new-id ignore free-identifier=?)
             #:unless (bound-identifier=? new-id (intro new-id 'remove)))
     (free-identifier=? new-id (datum->syntax orig (syntax->datum new-id)))))
 
@@ -197,9 +181,7 @@
                                     #:new-syntax new
                                     #:introduction-scope intro)
     replacement)
-  (define ignore (list #'ORIGINAL-GAP))
   (for/list ([new-id (in-syntax-identifiers new)]
-             #:unless (member new-id ignore free-identifier=?)
              #:unless (bound-identifier=? new-id (intro new-id 'remove))
              #:unless (free-identifier=? new-id (datum->syntax orig (syntax->datum new-id))))
     new-id))


### PR DESCRIPTION
This change adds an `#:original-splice` option to `~replacement` and replaces `ORIGINAL-GAP` with its usage. Some `ORIGINAL-GAP` uses have no equivalent and are discarded, as preserving original gaps is no longer worth the trouble now that `fmt` handles formatting decisions. Its only use is to preserve comments, and `~replacement` and `~splicing-replacement` do that well enough.