### PR TITLE
Always treat `\r\n` as `\n`

### DIFF
--- a/default-recommendations/windows-newline-test.rkt
+++ b/default-recommendations/windows-newline-test.rkt
@@ -1,0 +1,25 @@
+#lang racket/base
+
+
+(module+ test
+  (require rackunit
+           resyntax/default-recommendations
+           resyntax/testing/refactoring-test))
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(module+ test
+  (test-case "windows-style newlines should be replaced with regular newlines"
+    (define program
+      (string-append "#lang racket/base\r\n"
+                     "(define (foo)\r\n"
+                     "  (let ([x 42])\r\n"
+                     "    (* x 2)))\r\n"))
+    (define expected-program
+      (string-append "#lang racket/base\n"
+                     "(define (foo)\n"
+                     "  (define x 42)\n"
+                     "  (* x 2))\n"))
+    (check-suite-refactors default-recommendations program expected-program)))

--- a/main.rkt
+++ b/main.rkt
@@ -95,7 +95,7 @@
 (define (refactor code-string #:suite [suite default-recommendations])
   (define rule-list (refactoring-suite-rules suite))
   (define source (string-source code-string))
-  (define comments (with-input-from-string code-string read-comment-locations))
+  (define comments (with-input-from-source source read-comment-locations))
   (parameterize ([current-namespace (make-base-namespace)])
     (define analysis (source-analyze source))
     (refactor-visited-forms #:analysis analysis #:suite suite #:comments comments)))
@@ -118,7 +118,7 @@
                   [exn:fail:filesystem:missing-module? skip])
     (parameterize ([current-namespace (make-base-namespace)])
       (define analysis (source-analyze source #:lines lines))
-      (define comments (with-input-from-file path read-comment-locations #:mode 'text))
+      (define comments (with-input-from-source source read-comment-locations))
       (define full-source (source->string source))
       (for ([comment (in-range-set comments)])
         (log-resyntax-debug "parsed comment: ~a: ~v"

--- a/private/string-replacement.rkt
+++ b/private/string-replacement.rkt
@@ -68,7 +68,8 @@
          rebellion/streaming/reducer
          rebellion/streaming/transducer
          rebellion/type/record
-         rebellion/type/tuple)
+         rebellion/type/tuple
+         resyntax/private/source)
 
 
 (module+ test
@@ -211,7 +212,7 @@
 
 
 (define (file-apply-string-replacement! path replacement)
-  (define replacement-text (string-apply-replacement (file->string path #:mode 'text) replacement))
+  (define replacement-text (string-apply-replacement (source->string (file-source path)) replacement))
   (display-to-file replacement-text path #:mode 'text #:exists 'replace))
 
 

--- a/testing/refactoring-test.rkt
+++ b/testing/refactoring-test.rkt
@@ -4,6 +4,7 @@
 (provide (for-syntax #%datum)
          #%datum
          #%module-begin
+         check-suite-refactors
          refactoring-test
          refactoring-test-import
          refactoring-test-header
@@ -31,6 +32,7 @@
          resyntax
          resyntax/private/logger
          resyntax/private/refactoring-result
+         resyntax/private/source
          resyntax/private/string-replacement
          resyntax/refactoring-suite
          syntax/parse
@@ -152,7 +154,8 @@
            (λ () (transduce results
                             (mapping refactoring-result-string-replacement)
                             #:into union-into-string-replacement)))))
-      (define refactored-program (string-apply-replacement original-program replacement))
+      (define refactored-program
+        (string-apply-replacement (source->string (string-source original-program)) replacement))
       (with-check-info (['logs (build-logs-info)]
                         ['actual (string-block refactored-program)]
                         ['expected (string-block expected-program)])


### PR DESCRIPTION
Closes #272, hopefully.

As it turns out, the current code already converts `\r\n` to `\n` _when run on a Windows machine_, as that's what the `#:mode 'text` argument to the various file-reading utilities does. The problem in #272, however, is that a non-Windows system was running Resyntax on files that originally came from a Windows system. So the `\r\n` to `\n` replacement didn't happen even though `#:mode 'text` was used. Note that `read-syntax` _always_ treats `\r\n` as `\n` regardless of whether it's run on a Windows system or not. Since Resyntax is reading and writing files for the purposes of calling `read-syntax` on their contents, this pull request changes Resyntax to always replace `\r\n` with `\n` at read time regardless of what the current system is.