### PR TITLE
Add full expansion scopes to visited syntax

### DIFF
--- a/default-recommendations/for-loop-shortcuts-test.rkt
+++ b/default-recommendations/for-loop-shortcuts-test.rkt
@@ -263,7 +263,8 @@ test: "for/and with or to filter clause"
 
 test: "for/fold building hash to for/hash"
 ------------------------------
-(for/fold ([h (hash)]) ([x (in-range 0 10)])
+(for/fold ([h (hash)])
+          ([x (in-range 0 10)])
   (hash-set h x 'foo))
 ------------------------------
 ------------------------------
@@ -274,7 +275,8 @@ test: "for/fold building hash to for/hash"
 
 test: "for*/fold building hash to for*/hash"
 ------------------------------
-(for*/fold ([h (hash)]) ([x (in-range 0 10)])
+(for*/fold ([h (hash)])
+           ([x (in-range 0 10)])
   (hash-set h x 'foo))
 ------------------------------
 ------------------------------
@@ -285,18 +287,18 @@ test: "for*/fold building hash to for*/hash"
 
 test: "for/fold building hash can't be refactored when referring to hash"
 ------------------------------
-(for/fold ([h (hash)]) ([x (in-range 0 10)])
-  (displayln
-   (hash-has-key? h x))
+(for/fold ([h (hash)])
+          ([x (in-range 0 10)])
+  (displayln (hash-has-key? h x))
   (hash-set h x 'foo))
 ------------------------------
 
 
 test: "for*/fold building hash can't be refactored when referring to hash"
 ------------------------------
-(for*/fold ([h (hash)]) ([x (in-range 0 10)])
-  (displayln
-   (hash-has-key? h x))
+(for*/fold ([h (hash)])
+           ([x (in-range 0 10)])
+  (displayln (hash-has-key? h x))
   (hash-set h x 'foo))
 ------------------------------
 

--- a/default-recommendations/function-definition-shortcuts.rkt
+++ b/default-recommendations/function-definition-shortcuts.rkt
@@ -80,14 +80,26 @@
 (define-refactoring-rule define-case-lambda-to-define
   #:description "This use of `case-lambda` is equivalent to using `define` with optional arguments."
   #:literals (define case-lambda)
+
   (define id:id
     (case-lambda
       [(case1-arg:id ...) (usage:id usage1:id ... default:expr)]
       [(case2-arg:id ... bonus-arg:id) body ...]))
+
   #:when (oneline-syntax? #'default)
   #:when (free-identifier=? #'id #'usage)
-  #:when (free-identifiers=? #'(case1-arg ...) #'(case2-arg ...))
-  #:when (free-identifiers=? #'(case1-arg ...) #'(usage1 ...))
+
+  #:when (and (equal? (length (attribute case1-arg))
+                      (length (attribute case2-arg)))
+              (equal? (length (attribute case1-arg))
+                      (length (attribute usage1))))
+
+  #:when (for/and ([case1-arg-id (in-list (attribute case1-arg))]
+                   [case2-arg-id (in-list (attribute case2-arg))]
+                   [usage1-id (in-list (attribute usage1))])
+           (and (equal? (syntax-e case1-arg-id) (syntax-e case2-arg-id))
+                (equal? (syntax-e case1-arg-id) (syntax-e usage1-id))))
+
   (define (id case2-arg ... [bonus-arg default])
     body ...))
 

--- a/default-recommendations/let-binding-suggestions-test.rkt
+++ b/default-recommendations/let-binding-suggestions-test.rkt
@@ -235,6 +235,33 @@ test: "self-shadowing let*-values binding clause isn't refactorable"
 ------------------------------
 
 
+test: "let* with later right-hand-sides referring to earlier bindings is refactorable"
+------------------------------
+(define (f a)
+  (let* ([b (+ a 1)]
+         [c (+ b 1)]
+         [d (+ c 1)])
+    d))
+------------------------------
+------------------------------
+(define (f a)
+  (define b (+ a 1))
+  (define c (+ b 1))
+  (define d (+ c 1))
+  d)
+------------------------------
+
+
+test: "let* with later bindings shadowing earlier right-hand-sides not refactorable"
+------------------------------
+(define y 1)
+(define (f)
+  (let* ([x (+ y 1)]
+         [y (+ x 1)])
+    1))
+------------------------------
+
+
 test: "let forms inside lambdas"
 ------------------------------
 (λ ()
@@ -500,6 +527,15 @@ test: "variable definition with nested let binding of name bound earlier not ref
   (define x 5)
   (define y (let ([x 1]) (* x 2)))
   (* y 3))
+------------------------------
+
+
+test: "variable definition with nested let binding shadowing name used later not refactorable"
+------------------------------
+(define x 5)
+(define (f)
+  (define y (let ([x 1]) (* x 2)))
+  (* x y))
 ------------------------------
 
 

--- a/default-recommendations/private/let-binding.rkt
+++ b/default-recommendations/private/let-binding.rkt
@@ -1,452 +1,120 @@
 #lang racket/base
 
 
-(provide body-with-refactorable-let-expression
-         refactorable-let-expression)
+(require racket/contract/base)
 
 
-(require guard
-         racket/list
+(provide
+ body-with-refactorable-let-expression
+ refactorable-let-expression
+ (contract-out
+  [identifier-binding-unchanged-in-context? (-> identifier? syntax? boolean?)]
+  [identifier-has-exact-binding-in-context? (-> identifier? syntax? boolean?)]))
+
+
+(require racket/list
          racket/match
-         racket/sequence
-         racket/set
-         racket/syntax
-         rebellion/base/option
-         rebellion/collection/entry
-         rebellion/private/static-name
-         rebellion/streaming/reducer
-         rebellion/streaming/transducer
-         rebellion/type/record
-         resyntax/default-recommendations/private/graph
-         resyntax/private/source
+         resyntax/default-recommendations/private/syntax-identifier-sets
+         resyntax/default-recommendations/private/lambda-by-any-name
          resyntax/private/syntax-neighbors
-         resyntax/refactoring-rule
+         resyntax/private/logger
          syntax/id-set
          syntax/parse
-         syntax/parse/lib/function-header
-         syntax/stx)
-
-
-(module+ test
-  (require (submod "..")
-           rackunit))
+         syntax/parse/lib/function-header)
 
 
 ;@----------------------------------------------------------------------------------------------------
 
 
+(define-splicing-syntax-class body-with-refactorable-let-expression
+  #:attributes ([refactored 1])
+  (pattern
+    (~seq leading-body ... let-expression:refactorable-let-expression)
+    #:with (refactored ...) #'(leading-body ... (~@ let-expression.refactored ...))))
+
+
 (define-syntax-class refactorable-let-expression
   #:attributes ([refactored 1])
   #:literals (let let-values let* let*-values)
-
   (pattern
-    ((~or* let let-values) ~! bindings:refactorable-let-bindings body:body-forms)
-
-    #:when (no-binding-overlap?
-            (in-syntax #'(body.bound-id ...)) (in-syntax #'(bindings.inner-bound-id ...)))
-
-    #:when (no-binding-conflicts? (attribute bindings.bound-id) #'body.scopes)
-
-    #:when (attribute bindings.fully-refactorable?)
-    #:with (binding-definition ...)
-    #'(~splicing-replacement (bindings.outer-definition ...) #:original bindings)
+    (~or ((~or let let-values) ~! bindings:binding-group body ...+)
+         ((~or let* let*-values) ~! (~var bindings (binding-group #:nested? #true)) body ...+))
+    #:when (for/and ([id (attribute bindings.id)])
+             (not (identifier-has-exact-binding-in-context? id this-syntax)))
+    #:when (for/and ([id (attribute bindings.id)])
+             (identifier-binding-unchanged-in-context? id (first (attribute body))))
     #:with (refactored ...)
-    #`(~splicing-replacement (binding-definition ... body.formatted ...) #:original #,this-syntax))
-
-  (pattern ((~or* let* let*-values) ~! bindings:refactorable-let*-bindings body:body-forms)
-      
-    #:when (no-binding-overlap?
-            (in-syntax #'(body.bound-id ...)) (in-syntax #'(bindings.inner-bound-id ...)))
-
-    #:when (attribute bindings.fully-refactorable?)
-    #:with (binding-definition ...)
-    #'(~splicing-replacement (bindings.outer-definition ...) #:original bindings)
-    #:with (refactored ...)
-    #`(~splicing-replacement (binding-definition ... body.formatted ...)
-                             #:original #,this-syntax)))
-
-
-(define-splicing-syntax-class body-with-refactorable-let-expression
-  #:attributes ([refactored 1])
-  #:literals (let let-values let* let*-values)
-
-  (pattern
-    (~seq
-     leading-body:body-forms
-     (~and let-expression
-           ((~or* let let-values) ~! bindings:refactorable-let-bindings inner-body:body-forms)))
-    
-    #:when (no-binding-overlap? (syntax-identifiers #'leading-body)
-                                (in-syntax #'(bindings.outer-bound-id ...)))
-    #:when (no-binding-overlap? (in-syntax #'(inner-body.bound-id ...))
-                                (in-syntax #'(bindings.inner-bound-id ...)))
-
-    #:when (no-binding-conflicts? (attribute bindings.bound-id) #'inner-body.scopes)
-
-    #:when (attribute bindings.fully-refactorable?)
-
-    #:with (binding-definition ...)
-    #'(~splicing-replacement (bindings.outer-definition ...) #:original bindings)
-
-    #:with (refactored ...)
-    #'(leading-body.formatted ...
-       (~@ . (~splicing-replacement (binding-definition ... inner-body.formatted ...)
-                                    #:original let-expression))))
-
-  (pattern
-    (~seq
-     leading-body:body-forms
-     (~and let-expression
-           ((~or* let* let*-values) ~! bindings:refactorable-let*-bindings inner-body:body-forms)))
-    
-    #:when (no-binding-overlap? (syntax-identifiers #'leading-body)
-                                (in-syntax #'(bindings.outer-bound-id ...)))
-    #:when (no-binding-overlap? (in-syntax #'(inner-body.bound-id ...))
-                                (in-syntax #'(bindings.inner-bound-id ...)))
-
-    #:when (no-binding-conflicts? (attribute bindings.bound-id) #'inner-body.scopes)
-
-    #:when (attribute bindings.fully-refactorable?)
-
-    #:with (binding-definition ...)
-    #'(~splicing-replacement (bindings.outer-definition ...) #:original bindings)
-    
-    #:with (refactored ...)
-    #'(leading-body.formatted ...
-       (~@ . (~splicing-replacement (binding-definition ... inner-body.formatted ...)
-                                    #:original let-expression)))))
-
-
-(module+ test
-  (test-case (name-string body-with-refactorable-let-expression)
-
-    (define (parse stx)
-      (syntax-parse stx
-        [(let-expr:body-with-refactorable-let-expression) (syntax->datum #'(let-expr.refactored ...))]
-        [_ #false]))
-
-    (test-case "refactorable let bindings after non-conflicting definitions"
-      (define stx #'((define a 1) (let ([b a]) (+ a b))))
-      (define expected
-        '((define a 1)
-          (define b a)
-          (+ a b)))
-      (check-equal? (parse stx) expected))
-
-    (test-case "refactorable let* bindings after non-conflicting definitions"
-      (define stx #'((define a 1) (let* ([b a]) (+ a b))))
-      (define expected
-        '((define a 1)
-          (define b a)
-          (+ a b)))
-      (check-equal? (parse stx) expected))
-
-    (test-case "refactorable let bindings after conflicting definitions"
-      (define stx #'((define a 1) (let ([a 2]) a)))
-      (check-false (parse stx)))
-
-    (test-case "refactorable let* bindings after conflicting definitions"
-      (define stx #'((define a 1) (let* ([a 2]) a)))
-      (check-false (parse stx)))
-
-    (test-case "refactorable let bindings after capturing definitions"
-      (define stx #'((define a x) (let ([x 1]) (+ a x))))
-      (check-false (parse stx)))
-
-    (test-case "refactorable let* bindings after capturing definitions"
-      (define stx #'((define a x) (let* ([x 1]) (+ a x))))
-      (check-false (parse stx)))))
-
-
-(define-syntax-class refactorable-let-bindings
-  #:attributes ([bound-id 1]
-                [outer-bound-id 1]
-                [inner-bound-id 1]
-                [outer-definition 1]
-                fully-refactorable?)
-  (pattern (clause:binding-clause ...)
-    #:with (bound-id ...)
-    (append-map parsed-binding-clause-bound-identifiers (attribute clause.parsed))
-    #:do
-    [(define parsed-clauses (vector->immutable-vector (list->vector (attribute clause.parsed))))
-     (define deps (let-binding-clause-dependencies parsed-clauses))
-     (define depgraph (edges->graph deps #:vertex-count (vector-length parsed-clauses)))
-     (define graph
-       (parsed-binding-graph
-        #:clauses parsed-clauses
-        #:dependencies depgraph))
-     (define split (let-binding-graph-split graph))]
-    #:when (split-bindings-changed? split)
-    #:attr fully-refactorable? (split-bindings-fully-refactorable? split)
-    #:with (outer-bound-id ...) (split-bindings-outer-ids split)
-    #:with (inner-bound-id ...) (split-bindings-inner-ids split)
-    #:with (outer-definition ...) (split-bindings-outer-definitions split)))
-
-
-(define-syntax-class refactorable-let*-bindings
-  #:attributes ([bound-id 1]
-                [outer-bound-id 1]
-                [inner-bound-id 1]
-                [outer-definition 1]
-                fully-refactorable?)
-  (pattern (clause:binding-clause ...)
-    #:with (bound-id ...)
-    (append-map parsed-binding-clause-bound-identifiers (attribute clause.parsed))
-    #:do
-    [(define parsed-clauses (vector->immutable-vector (list->vector (attribute clause.parsed))))
-     (define deps (let-binding-clause-dependencies parsed-clauses))
-     (define depgraph (edges->graph deps #:vertex-count (vector-length parsed-clauses)))
-     (define graph
-       (parsed-binding-graph
-        #:clauses parsed-clauses
-        #:dependencies depgraph))
-     (define split (let*-binding-graph-split graph))]
-    #:when (split-bindings-changed? split)
-    #:attr fully-refactorable? (split-bindings-fully-refactorable? split)
-    #:with (outer-bound-id ...) (split-bindings-outer-ids split)
-    #:with (inner-bound-id ...) (split-bindings-inner-ids split)
-    #:with (outer-definition ...) (split-bindings-outer-definitions split)))
-
-
-(define (sequence->bound-id-set ids)
-  (immutable-bound-id-set (list->set (sequence->list ids))))
-
-
-(define (syntax-identifiers stx)
-  (cond
-    [(identifier? stx) (list stx)]
-    [(stx-list? stx)
-     (for*/list ([substx (in-syntax stx)]
-                 [subid (in-list (syntax-identifiers substx))])
-       subid)]
-    [else '()]))
-
-
-(module+ test
-  (test-case "syntax-identifiers"
-    (check-equal?
-     (map syntax->datum (syntax-identifiers #'(hello (darkness #:my old) friend)))
-     (list 'hello 'darkness 'old 'friend))))
-
-
-(define (no-binding-overlap? ids other-ids)
-  (define id-set (sequence->bound-id-set ids))
-  (define other-id-set (sequence->bound-id-set other-ids))
-  (bound-id-set-empty? (bound-id-set-intersect id-set other-id-set)))
-
-
-(module+ test
-  (test-case "no-binding-overlap?"
-    (check-true (no-binding-overlap? (in-syntax #'(a b c)) (in-syntax #'(d e f))))
-    (check-false (no-binding-overlap? (in-syntax #'(a b c)) (in-syntax #'(c d e))))
-    (check-true (no-binding-overlap? (in-syntax #'(a b c)) '()))
-    (check-true (no-binding-overlap? '() (in-syntax #'(d e f))))))
-
-
-(define/guard (no-binding-conflicts? ids body-scopes)
-  (define analysis (current-source-code-analysis))
-  (for/and ([x (in-list ids)])
-    (define x*
-      (if analysis
-          (hash-ref (source-code-analysis-scopes-by-location analysis) (syntax-source-location x) x)
-          x))
-    (free-identifier=? x* (datum->syntax body-scopes (syntax-e x)))))
-
-
-(define-record-type parsed-binding-clause
-  (original bound-identifiers identifier-side right-hand-side referenced-identifiers))
+    #`(~splicing-replacement (bindings.definition ... body ...) #:original #,this-syntax)))
 
 
 (define-syntax-class binding-clause
-  #:attributes (parsed)
-  (pattern (~and original [id:id rhs:expr])
-    #:attr parsed
-    (parsed-binding-clause
-     #:original #'original
-     #:bound-identifiers (list #'id)
-     #:identifier-side #'id
-     #:right-hand-side #'rhs
-     #:referenced-identifiers (syntax-identifiers #'rhs)))
-  (pattern (~and original [(~and id-side (id:id ...)) rhs:expr])
-    #:attr parsed
-    (parsed-binding-clause
-     #:original #'original
-     #:bound-identifiers (syntax->list #'(id ...))
-     #:identifier-side #'id-side
-     #:right-hand-side #'rhs
-     #:referenced-identifiers (syntax-identifiers #'rhs))))
+  #:attributes ([id 1] rhs definition)
+
+  (pattern [all-ids:id-list rhs:expr]
+    #:do [(log-resyntax-debug
+           "refactorable-let-expression: checking binding-clause not self shadowing: ~a"
+           this-syntax)]
+    #:when (for*/and ([rhs-free-id (in-free-id-set (syntax-free-identifiers (attribute rhs)))]
+                      [id (in-list (attribute all-ids.id))])
+             (log-resyntax-debug "refactorable-let-expression: checking identifier not shadowed: ~a"
+                                 rhs-free-id)
+             (identifier-binding-unchanged-in-context? rhs-free-id id))
+    #:cut
+    #:with (id ...) (attribute all-ids.id)
+    #:with definition
+    (match (attribute id)
+      ['() #'rhs]
+      [(list only-id)
+       (syntax-parse (attribute rhs)
+         [(_:lambda-by-any-name (arg:formal ...) body ...)
+          #`(define (#,only-id (~@ . arg) ...)
+              body ...)]
+         [(_:lambda-by-any-name (arg:formal ...+ . tail-arg) body ...)
+          #`(define (#,only-id (~@ . arg) ... . tail-arg)
+              body ...)]
+         [(_:lambda-by-any-name tail-arg:identifier body ...)
+          #`(define (#,only-id . tail-arg)
+              body ...)]
+         [_
+          #`(define (~replacement #,only-id #:original all-ids) rhs)])]
+      [_ #'(define-values all-ids rhs)])))
 
 
-(define (parsed-binding-clause-definition clause)
-  (define rhs (parsed-binding-clause-right-hand-side clause))
-  (define id-side (parsed-binding-clause-identifier-side clause))
-  (define definition
-    (match (parsed-binding-clause-bound-identifiers clause)
-    [(list id)
-     (syntax-parse rhs
-       #:literals (lambda λ)
-       [((~or lambda λ) (arg:formal ...) body ...)
-        #`(define (#,id (~@ (~? arg.kw) (~? [arg.name arg.default] arg.name)) ...)
-            body ...)]
-       [((~or lambda λ) (arg:formal ... . rest:identifier) body ...)
-        #`(define (#,id (~@ (~? arg.kw) (~? [arg.name arg.default] arg.name)) ... . rest)
-            body ...)]
-       [((~or lambda λ) args:identifier body ...)
-        #:with id* id
-        #`(define (id* . args)
-            body ...)]
-       [_ #`(define (~replacement #,id #:original #,id-side) #,rhs)])]
-    [_ #`(define-values #,id-side #,rhs)]))
-  #`(~replacement #,definition #:original #,(parsed-binding-clause-original clause)))
+(define-syntax-class id-list
+  #:attributes ([id 1])
+  (pattern only-id:id #:with (id ...) (list (attribute only-id)))
+  (pattern (id ...)))
 
 
-(define (binding-clause-depends-on? dependant dependency)
-  (define dependant-references (parsed-binding-clause-referenced-identifiers dependant))
-  (define dependency-ids (parsed-binding-clause-bound-identifiers dependency))
-  (not (no-binding-overlap? dependant-references dependency-ids)))
+(define-syntax-class (binding-group #:nested? [nested #false])
+  #:attributes ([id 1] [definition 1])
+  (pattern (clause:binding-clause ...)
+    #:when (or (not nested)
+               (for/and ([rhs (in-list (attribute clause.rhs))]
+                         [i (in-naturals)]
+                         #:when #true
+                         [ids (in-list (attribute clause.id))]
+                         [j (in-naturals)]
+                         #:when (< i j)
+                         [id (in-list ids)]
+                         #:when #true
+                         [rhs-free-id (in-free-id-set (syntax-free-identifiers rhs))])
+                 (identifier-binding-unchanged-in-context? rhs-free-id id)))
+    #:cut
+    #:with (id ...) #'(clause.id ... ...)
+    #:with (definition ...)
+    #`(~splicing-replacement ((~replacement clause.definition #:original clause) ...)
+                             #:original #,this-syntax)))
 
 
-(define-record-type parsed-binding-graph (clauses dependencies))
+(define (identifier-binding-unchanged-in-context? id context)
+  (define add-context (make-syntax-delta-introducer context #false))
+  (free-identifier=? id (add-context id)))
 
 
-(define (let-binding-clause-dependencies clauses)
-  (for*/list ([(dependant i) (in-indexed (in-vector clauses))]
-              [(dependency j) (in-indexed (in-vector clauses))]
-              #:when (binding-clause-depends-on? dependant dependency))
-    (entry i j)))
-    
-
-(define-record-type split-bindings (before-cycles cycles after-cycles changed?))
+(define (identifier-has-exact-binding-in-context? id context)
+  (and (identifier-binding (identifier-in-context id context) 0 #false #true) #true))
 
 
-(define/guard (let-binding-graph-split graph)
-  (define binding-count (vector-length (parsed-binding-graph-clauses graph)))
-  (define cycle-indices (graph-cycle-vertices (parsed-binding-graph-dependencies graph)))
-  (define changed? (not (equal? (length cycle-indices) binding-count)))
-  (guard (not (empty? cycle-indices)) #:else
-    (split-bindings
-     #:before-cycles (vector->list (parsed-binding-graph-clauses graph))
-     #:cycles '()
-     #:after-cycles '()
-     #:changed? changed?))
-  (define cycle-start-index (transduce cycle-indices #:into (nonempty-into-min)))
-  (define cycle-end-index (add1 (transduce cycle-indices #:into (nonempty-into-max))))
-  (define before-cycles
-    (for/list ([i (in-range 0 cycle-start-index)])
-      (vector-ref (parsed-binding-graph-clauses graph) i)))
-  (define cycles
-    (for/list ([i (in-range cycle-start-index cycle-end-index)])
-      (vector-ref (parsed-binding-graph-clauses graph) i)))
-  (define after-cycles
-    (for/list ([i (in-range cycle-end-index binding-count)])
-      (vector-ref (parsed-binding-graph-clauses graph) i)))
-  (split-bindings
-   #:before-cycles before-cycles
-   #:cycles cycles
-   #:after-cycles after-cycles
-   #:changed? changed?))
-
-
-(define/guard (let*-binding-graph-split graph)
-  (define binding-count (vector-length (parsed-binding-graph-clauses graph)))
-  (define (referenced-by-earlier? i)
-    (define earliest-predecessor
-      (transduce (graph-predecessors (parsed-binding-graph-dependencies graph) i) #:into into-first))
-    (match earliest-predecessor
-      [(present s) (<= s i)]
-      [_ #false]))
-  (define cycle-start-index-opt
-    (transduce (in-range 0 binding-count)
-               (filtering referenced-by-earlier?)
-               #:into into-first))
-  (guard-match (present cycle-start-index) cycle-start-index-opt #:else
-    (split-bindings
-     #:before-cycles (vector->list (parsed-binding-graph-clauses graph))
-     #:cycles '()
-     #:after-cycles '()
-     #:changed? (positive? binding-count)))
-  (define cycle-end-index
-    (add1
-     (transduce (in-range (sub1 binding-count) -1 -1)
-                (filtering referenced-by-earlier?)
-                #:into nonempty-into-first)))
-  (define before-cycles
-    (for/list ([i (in-range 0 cycle-start-index)])
-      (vector-ref (parsed-binding-graph-clauses graph) i)))
-  (define cycles
-    (for/list ([i (in-range cycle-start-index cycle-end-index)])
-      (vector-ref (parsed-binding-graph-clauses graph) i)))
-  (define after-cycles
-    (for/list ([i (in-range cycle-end-index binding-count)])
-      (vector-ref (parsed-binding-graph-clauses graph) i)))
-  (split-bindings
-   #:before-cycles before-cycles
-   #:cycles cycles
-   #:after-cycles after-cycles
-   #:changed? (or (not (empty? before-cycles)) (not (empty? after-cycles)))))
-
-
-(define (split-bindings-fully-refactorable? split)
-  (and (empty? (split-bindings-cycles split))
-       (empty? (split-bindings-after-cycles split))))
-
-
-(define (split-bindings-outer-ids split)
-  (for*/list ([before (in-list (split-bindings-before-cycles split))]
-              [id (in-list (parsed-binding-clause-bound-identifiers before))])
-    id))
-
-
-(define (split-bindings-inner-ids split)
-  (for*/list ([after (in-list (split-bindings-after-cycles split))]
-              [id (in-list (parsed-binding-clause-bound-identifiers after))])
-    id))
-
-
-(define (split-bindings-outer-definitions split)
-  (define/with-syntax (definition ...)
-    (for/list ([before (in-list (split-bindings-before-cycles split))])
-      (parsed-binding-clause-definition before)))
-  #'(definition ...))
-
-
-(define-syntax-class body-form
-  #:literals (define define-syntax define-values define-syntaxes)
-  #:attributes ([bound-id 1])
-  (pattern (define id:id ~! _) #:with (bound-id ...) #'(id))
-  (pattern (define header:function-header ~! _ ...) #:with (bound-id ...) #'(header.name))
-  (pattern (define-syntax id:id ~! _) #:with (bound-id ...) #'(id))
-  (pattern (define-syntax header:function-header ~! _ ...) #:with (bound-id ...) #'(header.name))
-  (pattern (define-values ~! (bound-id:id ...) _))
-  (pattern (define-syntaxes ~! (bound-id:id ...) _))
-  (pattern _ #:with (bound-id ...) #'()))
-
-
-(define-splicing-syntax-class body-forms
-  #:attributes (scopes [bound-id 1] [formatted 1])
-  (pattern (~seq form:body-form ...)
-    #:with scopes
-    (or (for/or ([b (in-list (reverse (attribute form)))])
-          (define analysis (current-source-code-analysis))
-          (and analysis
-               (hash-ref (source-code-analysis-scopes-by-location analysis)
-                         (syntax-source-location b)
-                         #false)))
-        (and (pair? (attribute form)) (last (attribute form))))
-    #:with (bound-id ...) #'(form.bound-id ... ...)
-    #:with (formatted ...) #'(form ...)))
-
-
-(module+ test
-  (test-case "body-form"
-    (define (parse stx) (syntax-parse stx [form:body-form (syntax->datum #'(form.bound-id ...))]))
-    (check-equal? (parse #'(define a 42)) (list 'a))
-    (check-equal? (parse #'(define (f a b c) 42)) (list 'f))
-    (check-equal? (parse #'(define (((f a) b) c) 42)) (list 'f))
-    (check-equal? (parse #'(define-syntax a 42)) (list 'a))
-    (check-equal? (parse #'(define-syntax (f a b c) 42)) (list 'f))
-    (check-equal? (parse #'(define-syntax (((f a) b) c) 42)) (list 'f))
-    (check-equal? (parse #'(define-values (a b c) 42)) (list 'a 'b 'c))
-    (check-equal? (parse #'(define-syntaxes (a b c) 42)) (list 'a 'b 'c))
-    (check-equal? (parse #'(void)) '())))
-
+(define (identifier-in-context id context)
+  (datum->syntax context (syntax-e id) id id))

--- a/main.rkt
+++ b/main.rkt
@@ -56,7 +56,7 @@
             absent)])
       (guarded-block
         (guard-match (present replacement)
-          (refactoring-rule-refactor rule syntax #:analysis analysis)
+          (refactoring-rule-refactor rule syntax)
           #:else absent)
         (guard (syntax-replacement-introduces-incorrect-bindings? replacement) #:else
           (log-resyntax-warning

--- a/private/linemap.rkt
+++ b/private/linemap.rkt
@@ -97,8 +97,17 @@
 
 
 (define (syntax-line-range stx #:linemap map)
-  (define end-line (linemap-position-to-line map (+ (syntax-position stx) (syntax-span stx))))
-  (closed-range (syntax-line stx) end-line #:comparator natural<=>))
+  (define first-line (syntax-line stx))
+  (define last-line (linemap-position-to-line map (+ (syntax-position stx) (syntax-span stx))))
+  (unless (<= first-line last-line)
+    (raise-arguments-error 'syntax-line-range
+                           "syntax object's last line number is before its first line number"
+                           "syntax" stx
+                           "first line" first-line
+                           "last line" last-line
+                           "position" (syntax-position stx)
+                           "span" (syntax-span stx)))
+  (closed-range first-line last-line #:comparator natural<=>))
 
 
 (module+ test


### PR DESCRIPTION
Closes #276. This allows a complete rework and immense simplification of the `let-to-define` logic. It also removes the need to pass the full source code analysis object to each refactoring rule, since all of the information produced by the analysis is now embedded in the syntax object handed to the refactoring rule.

This commit also adds some miscellaneous observability improvements, including more debug logging and better error messages.