### PR TITLE
Add `read-line-any` rule

### DIFF
--- a/default-recommendations.rkt
+++ b/default-recommendations.rkt
@@ -8,6 +8,7 @@
  (all-from-out resyntax/default-recommendations/boolean-shortcuts
                resyntax/default-recommendations/comparison-shortcuts
                resyntax/default-recommendations/conditional-shortcuts
+               resyntax/default-recommendations/console-io-suggestions
                resyntax/default-recommendations/contract-shortcuts
                resyntax/default-recommendations/definition-shortcuts
                resyntax/default-recommendations/file-io-suggestions
@@ -36,6 +37,7 @@
          resyntax/default-recommendations/boolean-shortcuts
          resyntax/default-recommendations/comparison-shortcuts
          resyntax/default-recommendations/conditional-shortcuts
+         resyntax/default-recommendations/console-io-suggestions
          resyntax/default-recommendations/contract-shortcuts
          resyntax/default-recommendations/definition-shortcuts
          resyntax/default-recommendations/file-io-suggestions
@@ -66,6 +68,7 @@
   #:suites (boolean-shortcuts
             comparison-shortcuts
             conditional-shortcuts
+            console-io-suggestions
             contract-shortcuts
             definition-shortcuts
             file-io-suggestions

--- a/default-recommendations/console-io-suggestions-test.rkt
+++ b/default-recommendations/console-io-suggestions-test.rkt
@@ -1,0 +1,30 @@
+#lang resyntax/testing/refactoring-test
+
+
+require: resyntax/default-recommendations console-io-suggestions
+
+
+header:
+- #lang racket/base
+
+
+test: "should suggest 'any linemode with read-line when linemode not specified"
+----------------------------------------
+(define (foo in)
+  (read-line in))
+----------------------------------------
+----------------------------------------
+(define (foo in)
+  (read-line in 'any))
+----------------------------------------
+
+
+test: "should suggest 'any linemode with read-line when linemode and port not specified"
+----------------------------------------
+(define (foo)
+  (read-line))
+----------------------------------------
+----------------------------------------
+(define (foo)
+  (read-line (current-input-port) 'any))
+----------------------------------------

--- a/default-recommendations/console-io-suggestions.rkt
+++ b/default-recommendations/console-io-suggestions.rkt
@@ -1,0 +1,32 @@
+#lang racket/base
+
+
+(require racket/contract/base)
+
+
+(provide
+ (contract-out
+  [console-io-suggestions refactoring-suite?]))
+
+
+(require racket/file
+         racket/list
+         rebellion/private/static-name
+         resyntax/base
+         syntax/parse)
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(define-refactoring-rule read-line-any
+  #:description
+  (string-append "Specify a line mode of `'any` with `read-line` to avoid differences between "
+                 "Windows and other platforms.")
+  #:literals (read-line)
+  (read-line (~optional port))
+  (read-line (~? port (current-input-port)) 'any))
+
+
+(define-refactoring-suite console-io-suggestions
+  #:rules (read-line-any))


### PR DESCRIPTION
Closes #211. Also, fix `in-syntax-identifiers` to skip quoted identifiers.