### PR TITLE
Format less when migrating `define-simple-macro`

### DIFF
--- a/default-recommendations/syntax-parse-shortcuts-test.rkt
+++ b/default-recommendations/syntax-parse-shortcuts-test.rkt
@@ -41,3 +41,30 @@ test: "define-syntax-parse-rule not refactorable (https://github.com/jackfirth/r
   ;; The let form is needed to avoid evaluating a twice.
   (let ([tmp a]) (if a a b)))
 ------------------------------
+
+
+test: "migrating define-simple-macro doesn't reformat the entire macro definition"
+------------------------------
+(define-simple-macro (my-or a:expr b:expr)
+  ( let   ([tmp a]   )
+     (if    a a b)))
+------------------------------
+------------------------------
+(define-syntax-parse-rule (my-or a:expr b:expr)
+  ( let   ([tmp a]   )
+     (if    a a b)))
+------------------------------
+
+
+test: "migrating define-simple-macro does reformat the macro definition when the header is long"
+------------------------------
+(define-simple-macro (my-or a:expr b:expr fooooooooooooooooooooooooooooooooooooooooooooooooooooooo)
+  ( let   ([tmp a]   )
+     (if    a a b)))
+------------------------------
+------------------------------
+(define-syntax-parse-rule (my-or a:expr
+                                 b:expr
+                                 fooooooooooooooooooooooooooooooooooooooooooooooooooooooo)
+  (let ([tmp a]) (if a a b)))
+------------------------------

--- a/default-recommendations/syntax-parse-shortcuts.rkt
+++ b/default-recommendations/syntax-parse-shortcuts.rkt
@@ -9,16 +9,16 @@
   [syntax-parse-shortcuts refactoring-suite?]))
 
 
-(require rebellion/private/static-name
-         resyntax/base
-         resyntax/private/syntax-neighbors
-         resyntax/private/syntax-replacement
-         syntax/parse
+(require resyntax/base
+         resyntax/default-recommendations/private/syntax-lines
          syntax/parse/define)
 
 
 ;@----------------------------------------------------------------------------------------------------
 
+
+(define define-simple-macro-migration-name-length-increase
+  (- (string-length "define-syntax-parse-rule") (string-length "define-simple-macro")))
 
 (define-refactoring-rule define-simple-macro-to-define-syntax-parse-rule
   #:description "The `define-simple-macro` form has been renamed to `define-syntax-parse-rule`."
@@ -29,8 +29,21 @@
   ;; free-identifier=?. As a result, we need to check the actual symbol of the identifier instead of
   ;; just its binding. See https://github.com/jackfirth/resyntax/issues/106.
   #:when (equal? (syntax-e #'original) 'define-simple-macro)
+
+  #:do
+  [(define should-reformat?
+     (and (equal? (syntax-line #'original) (syntax-line #'header))
+          (oneline-syntax? #'header)
+          (> (+ (syntax-column #'header)
+                (syntax-span #'header)
+                define-simple-macro-migration-name-length-increase)
+             102)))]
+
+  #:with new-id (if should-reformat?
+                    #'define-syntax-parse-rule
+                    #'(~focus-replacement-on define-syntax-parse-rule))
    
-  ((~replacement define-syntax-parse-rule #:original original) header form ...))
+  (new-id header form ...))
 
 
 (define-refactoring-suite syntax-parse-shortcuts


### PR DESCRIPTION
Closes #317.