### PR TITLE
Don't reformat entire context when removing `define-values`

### DIFF
--- a/default-recommendations/definition-shortcuts-test.rkt
+++ b/default-recommendations/definition-shortcuts-test.rkt
@@ -61,6 +61,29 @@ test: "define-values with values inside cond refactorable to separate definition
 ------------------------------
 
 
+test: "refactoring define-values to separate definitions doesn't reformat context"
+------------------------------
+(define (foo)
+
+  (  displayln   "foo"   )
+
+  (define-values (a b c) (values 1 2 3))
+
+  (  +  a  b   c ))
+------------------------------
+------------------------------
+(define (foo)
+
+  (  displayln   "foo"   )
+
+  (define a 1)
+  (define b 2)
+  (define c 3)
+
+  (  +  a  b   c ))
+------------------------------
+
+
 test: "immediately returned variable definition can be inlined"
 ------------------------------
 (define (foo)

--- a/default-recommendations/definition-shortcuts.rkt
+++ b/default-recommendations/definition-shortcuts.rkt
@@ -23,9 +23,11 @@
   #:description "This use of `define-values` is unnecessary."
   #:literals (define-values values)
   (~seq body-before ...
-        (define-values (id:id ...) (values expr:expr ...))
+        (~and definition (define-values (id:id ...) (values expr:expr ...)))
         body-after ...)
-  (body-before ... (define id expr) ... body-after ...))
+  #:with (replacement ...)
+  #'(~focus-replacement-on (~splicing-replacement ((define id expr) ...) #:original definition))
+  (body-before ... replacement ... body-after ...))
 
 
 (define-definition-context-refactoring-rule inline-unnecessary-define


### PR DESCRIPTION
Saw this in racket/typed-racket#1402.