### PR TITLE
Rename testing language

### DIFF
--- a/default-recommendations/boolean-shortcuts-test.rkt
+++ b/default-recommendations/boolean-shortcuts-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations boolean-shortcuts

--- a/default-recommendations/comparison-shortcuts-test.rkt
+++ b/default-recommendations/comparison-shortcuts-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations comparison-shortcuts

--- a/default-recommendations/conditional-shortcuts-test.rkt
+++ b/default-recommendations/conditional-shortcuts-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations conditional-shortcuts

--- a/default-recommendations/console-io-suggestions-test.rkt
+++ b/default-recommendations/console-io-suggestions-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations console-io-suggestions

--- a/default-recommendations/contract-shortcuts-test.rkt
+++ b/default-recommendations/contract-shortcuts-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations contract-shortcuts

--- a/default-recommendations/definition-shortcuts-test.rkt
+++ b/default-recommendations/definition-shortcuts-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations definition-shortcuts

--- a/default-recommendations/file-io-suggestions-test.rkt
+++ b/default-recommendations/file-io-suggestions-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations file-io-suggestions

--- a/default-recommendations/for-loop-shortcuts-test.rkt
+++ b/default-recommendations/for-loop-shortcuts-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations for-loop-shortcuts

--- a/default-recommendations/formatting-preservation-test.rkt
+++ b/default-recommendations/formatting-preservation-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations default-recommendations

--- a/default-recommendations/function-definition-shortcuts-test.rkt
+++ b/default-recommendations/function-definition-shortcuts-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations function-definition-shortcuts

--- a/default-recommendations/function-shortcuts-test.rkt
+++ b/default-recommendations/function-shortcuts-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations function-shortcuts

--- a/default-recommendations/gap-preservation-test.rkt
+++ b/default-recommendations/gap-preservation-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations/gap-preservation gap-preservation-rules

--- a/default-recommendations/hash-shortcuts-test.rkt
+++ b/default-recommendations/hash-shortcuts-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations hash-shortcuts

--- a/default-recommendations/legacy-contract-migrations-test.rkt
+++ b/default-recommendations/legacy-contract-migrations-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations legacy-contract-migrations

--- a/default-recommendations/legacy-struct-migrations-test.rkt
+++ b/default-recommendations/legacy-struct-migrations-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations legacy-struct-migrations

--- a/default-recommendations/legacy-syntax-migrations-test.rkt
+++ b/default-recommendations/legacy-syntax-migrations-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations legacy-syntax-migrations

--- a/default-recommendations/let-binding-suggestions-comment-test.rkt
+++ b/default-recommendations/let-binding-suggestions-comment-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations let-binding-suggestions

--- a/default-recommendations/let-binding-suggestions-function-shortcuts-test.rkt
+++ b/default-recommendations/let-binding-suggestions-function-shortcuts-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations let-binding-suggestions

--- a/default-recommendations/let-binding-suggestions-nesting-test.rkt
+++ b/default-recommendations/let-binding-suggestions-nesting-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations let-binding-suggestions

--- a/default-recommendations/let-binding-suggestions-test.rkt
+++ b/default-recommendations/let-binding-suggestions-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations let-binding-suggestions

--- a/default-recommendations/list-shortcuts-test.rkt
+++ b/default-recommendations/list-shortcuts-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations list-shortcuts

--- a/default-recommendations/match-shortcuts-test.rkt
+++ b/default-recommendations/match-shortcuts-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations match-shortcuts

--- a/default-recommendations/numeric-shortcuts-test.rkt
+++ b/default-recommendations/numeric-shortcuts-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations numeric-shortcuts

--- a/default-recommendations/require-and-provide-suggestions-test.rkt
+++ b/default-recommendations/require-and-provide-suggestions-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations require-and-provide-suggestions

--- a/default-recommendations/shadowed-output-test.rkt
+++ b/default-recommendations/shadowed-output-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations default-recommendations

--- a/default-recommendations/string-shortcuts-test.rkt
+++ b/default-recommendations/string-shortcuts-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations string-shortcuts

--- a/default-recommendations/syntax-parse-shortcuts-test.rkt
+++ b/default-recommendations/syntax-parse-shortcuts-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations syntax-parse-shortcuts

--- a/default-recommendations/syntax-rules-shortcuts-test.rkt
+++ b/default-recommendations/syntax-rules-shortcuts-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations syntax-rules-shortcuts

--- a/default-recommendations/syntax-shortcuts-test.rkt
+++ b/default-recommendations/syntax-shortcuts-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations syntax-shortcuts

--- a/default-recommendations/unused-binding-suggestions-test.rkt
+++ b/default-recommendations/unused-binding-suggestions-test.rkt
@@ -1,4 +1,4 @@
-#lang resyntax/testing/refactoring-test
+#lang resyntax/test
 
 
 require: resyntax/default-recommendations unused-binding-suggestions

--- a/default-recommendations/windows-newline-test.rkt
+++ b/default-recommendations/windows-newline-test.rkt
@@ -4,7 +4,7 @@
 (module+ test
   (require rackunit
            resyntax/default-recommendations
-           resyntax/testing/refactoring-test))
+           resyntax/test))
 
 
 ;@----------------------------------------------------------------------------------------------------

--- a/test.rkt
+++ b/test.rkt
@@ -299,7 +299,7 @@
     (define parse-tree (parse source-name (make-refactoring-test-tokenizer in)))
     (define module-datum
       `(module refactoring-test racket/base
-         (module test resyntax/testing/refactoring-test
+         (module test resyntax/test
            ,parse-tree)))
     (datum->syntax #f module-datum))
 


### PR DESCRIPTION
The name `#lang resyntax/test` is much snappier.