### PR TITLE
Add `@lines` test parameter

### DIFF
--- a/default-recommendations/definition-shortcuts-test.rkt
+++ b/default-recommendations/definition-shortcuts-test.rkt
@@ -84,6 +84,31 @@ test: "refactoring define-values to separate definitions doesn't reformat contex
 ------------------------------
 
 
+test: "refactoring define-values to separate definitions respects requested line range"
+@lines 2..3
+------------------------------
+(define (foo)
+  (define-values (a b c)
+    (values 1 2 3))
+  (+ a b c))
+(define (bar)
+  (define-values (x y z)
+    (values 4 5 6))
+  (+ x y z))
+------------------------------
+------------------------------
+(define (foo)
+  (define a 1)
+  (define b 2)
+  (define c 3)
+  (+ a b c))
+(define (bar)
+  (define-values (x y z)
+    (values 4 5 6))
+  (+ x y z))
+------------------------------
+
+
 test: "immediately returned variable definition can be inlined"
 ------------------------------
 (define (foo)
@@ -141,4 +166,29 @@ test: "inlining immediately returned variable definition in empty context does r
 ------------------------------
 (map (λ (x) (* x 2))
      (list 1 2 3))
+------------------------------
+
+
+test: "inlining immediately returned variable definition respects requested line range"
+@lines 4..6
+------------------------------
+(define (foo)
+  (define x 1)
+  x)
+(define (bar)
+  (define x 1)
+  x)
+(define (baz)
+  (define x 1)
+  x)
+------------------------------
+------------------------------
+(define (foo)
+  (define x 1)
+  x)
+(define (bar)
+  1)
+(define (baz)
+  (define x 1)
+  x)
 ------------------------------

--- a/main.rkt
+++ b/main.rkt
@@ -7,7 +7,8 @@
 (provide
  (contract-out
   [refactor! (-> (sequence/c refactoring-result?) void?)]
-  [refactor (->* (string?) (#:suite refactoring-suite?) (listof refactoring-result?))]
+  [refactor
+   (->* (string?) (#:suite refactoring-suite? #:lines range-set?) (listof refactoring-result?))]
   [refactor-file (->* (file-portion?) (#:suite refactoring-suite?) (listof refactoring-result?))]))
 
 

--- a/test/private/grammar.rkt
+++ b/test/private/grammar.rkt
@@ -1,9 +1,9 @@
 #lang brag
 
 begin: statement*
-statement: COLON-IDENTIFIER (expression | option)+
-@expression: IDENTIFIER | LITERAL-STRING | LITERAL-INTEGER | closed-range | range-set | code-block
+statement: COLON-IDENTIFIER (option | code-block | expression)+
+@expression: range-set | IDENTIFIER | LITERAL-STRING | LITERAL-INTEGER
 option: AT-SIGN-IDENTIFIER expression
 code-block: CODE-BLOCK
-closed-range: LITERAL-INTEGER /DOUBLE-DOT LITERAL-INTEGER
-range-set: closed-range (/COMMA closed-range)+
+range-set: line-range (/COMMA line-range)*
+line-range: LITERAL-INTEGER /DOUBLE-DOT LITERAL-INTEGER

--- a/test/private/tokenizer.rkt
+++ b/test/private/tokenizer.rkt
@@ -49,7 +49,7 @@
 
 (define-lex-abbrev refactoring-test-identifier
   (concatenation alphabetic
-                 (repetition 0 +inf.0 (union alphabetic symbolic numeric (char-set "-/")))))
+                 (repetition 0 +inf.0 (union alphabetic numeric (char-set "-/")))))
 
 
 (define-tokens refactoring-test-tokens


### PR DESCRIPTION
This allows controlling the set of lines analyzed by Resyntax in `#lang resyntax/test`. Closes #314.