### PR TITLE
Refactor `in-range` to `in-inclusive-range` when possible

### DIFF
--- a/default-recommendations/for-loop-shortcuts-test.rkt
+++ b/default-recommendations/for-loop-shortcuts-test.rkt
@@ -788,3 +788,14 @@ test: "(unless ...) in a for* loop refactored to #:when clause"
        #:unless (number? x))
   (displayln x))
 ------------------------------------------------------------
+
+
+test: "in-range with add1 in a for loop can be refactored to in-inclusive-range"
+------------------------------------------------------------
+(for ([i (in-range 1 (add1 5))])
+  (displayln i))
+------------------------------------------------------------
+------------------------------------------------------------
+(for ([i (in-inclusive-range 1 5)])
+  (displayln i))
+------------------------------------------------------------

--- a/default-recommendations/for-loop-shortcuts.rkt
+++ b/default-recommendations/for-loop-shortcuts.rkt
@@ -462,6 +462,13 @@ return just that result."
   (for-id (clause ... #:unless condition) body ...))
 
 
+(define-refactoring-rule in-range-with-add1-to-in-inclusive-range
+  #:description "Use `in-inclusive-range` to include the upper bound value in the iterated sequence."
+  #:literals (in-range add1 +)
+  (in-range start (~or (add1 end) (+ end 1) (+ 1 end)))
+  (in-inclusive-range start end))
+
+
 (define-refactoring-suite for-loop-shortcuts
   #:rules (andmap-to-for/and
            append-map-for/list-to-for*/list
@@ -472,6 +479,7 @@ return just that result."
            for/fold-with-conditional-body-to-unless-keyword
            for/fold-with-conditional-body-to-when-keyword
            for-each-to-for
+           in-range-with-add1-to-in-inclusive-range
            list->set-to-for/set
            list->vector-to-for/vector
            map-to-for

--- a/private/source.rkt
+++ b/private/source.rkt
@@ -149,6 +149,12 @@
     (define expanded
       (parameterize ([current-expand-observe observe-event!])
         (expand program-stx)))
+
+    (for ([visited (in-vector (fully-expanded-syntax-disappeared-visits expanded))]
+          #:when (resyntax-should-analyze-syntax? visited))
+      (vector-builder-add original-visits visited)
+      (add-all-original-subforms! visited))
+
     (define binding-table (fully-expanded-syntax-binding-table expanded))
     (define original-binding-table-by-position
       (for*/fold ([table (hash)])


### PR DESCRIPTION
Closes #153 and closes #369.

I'm keeping this open as a draft for now. It relies on a patch to Racket to emit a `'disappeared-visit` syntax property. I'm not sure yet if this will work for uses of `in-range` in `for` at higher phases.