### PR TITLE
Add modified sources and use them for new analysis API

### DIFF
--- a/cli.rkt
+++ b/cli.rkt
@@ -222,7 +222,11 @@ For help on these, use 'analyze --help' or 'fix --help'."
   (printf "resyntax: --- analyzing code ---\n")
   (define results
     (transduce files
-               (append-mapping (refactor-file _ #:suite (resyntax-analyze-options-suite options)))
+               (append-mapping
+                (λ (portion)
+                  (resyntax-analyze (file-source (file-portion-path portion))
+                                    #:suite (resyntax-analyze-options-suite options)
+                                    #:lines (file-portion-lines portion))))
                #:into into-list))
 
   (define (display-results)
@@ -373,9 +377,12 @@ For help on these, use 'analyze --help' or 'fix --help'."
                ;; a convenient manner.
                
                (append-mapping entry-value) ; throw away the file path, we don't need it anymore
-               (append-mapping (λ (p)
-                                 (refactor-file (filter-file-portion p lines-to-analyze-by-file)
-                                                #:suite (resyntax-fix-options-suite options))))
+               (mapping (filter-file-portion _ lines-to-analyze-by-file))
+               (append-mapping
+                (λ (portion)
+                  (resyntax-analyze (file-portion-path portion)
+                                    #:suite (resyntax-fix-options-suite options)
+                                    #:lines (file-portion-lines portion))))
                (limiting max-modified-lines
                          #:by (λ (result)
                                 (define replacement (refactoring-result-line-replacement result))

--- a/test/private/rackunit.rkt
+++ b/test/private/rackunit.rkt
@@ -123,8 +123,9 @@
   (define results
     (call-with-logs-captured
      (λ ()
-       (refactor (code-block-raw-string original-program)
-                 #:suite suite #:lines modified-line-mask))))
+       (resyntax-analyze (string-source (code-block-raw-string original-program))
+                         #:suite suite
+                         #:lines modified-line-mask))))
   
   (with-check-info*
       (if (empty? results)
@@ -189,7 +190,8 @@
 
   (define results
     (call-with-logs-captured
-     (λ () (refactor (code-block-raw-string original-program) #:suite suite))))
+     (λ ()
+       (resyntax-analyze (string-source (code-block-raw-string original-program)) #:suite suite))))
   (define replacement
     (transduce results
                (mapping refactoring-result-string-replacement)


### PR DESCRIPTION
Part of #380. Now Resyntax can analyze files after prior modifications without actually modifying the files.