### PR TITLE
Add more `begin` rules

### DIFF
--- a/default-recommendations/definition-shortcuts-test.rkt
+++ b/default-recommendations/definition-shortcuts-test.rkt
@@ -236,3 +236,21 @@ test: "begin inside begin0 in definition context should be extractable"
   (begin0 (* x 2)
     (displayln "after")))
 --------------------
+
+
+test: "begin inside definition context should be flattenable"
+--------------------
+(define (f x)
+  (displayln "starting")
+  (begin
+    (define y (* x 2))
+    (define z (* y 3)))
+  (+ x y z))
+--------------------
+--------------------
+(define (f x)
+  (displayln "starting")
+  (define y (* x 2))
+  (define z (* y 3))
+  (+ x y z))
+--------------------

--- a/default-recommendations/definition-shortcuts.rkt
+++ b/default-recommendations/definition-shortcuts.rkt
@@ -81,9 +81,19 @@
   (body-before ... replacement ...))
 
 
+(define-definition-context-refactoring-rule inline-unnecessary-begin
+  #:description "This `begin` form can be flattened into the surrounding definition context."
+  #:literals (begin)
+  (~seq body-before ... (~and original (begin inner-body ...)) body-after ...)
+  #:with (replacement ...)
+  #'(~focus-replacement-on (~splicing-replacement (inner-body ...) #:original original))
+  (body-before ... inner-body ... body-after ...))
+
+
 (define-refactoring-suite definition-shortcuts
   #:rules (begin0-begin-extraction
             define-begin-extraction
             define-begin0-extraction
             define-values-values-to-define
+            inline-unnecessary-begin
             inline-unnecessary-define))

--- a/default-recommendations/let-binding-suggestions-test.rkt
+++ b/default-recommendations/let-binding-suggestions-test.rkt
@@ -697,6 +697,23 @@ test: "let binding nested in begin0 extractable to definition"
 ------------------------------
 
 
+test: "let binding with body nested in begin0 extractable to definition and body"
+------------------------------
+(define (f)
+  (begin0 (let ([x 1])
+            (displayln "foo")
+            x)
+    (displayln "bar")))
+------------------------------
+------------------------------
+(define (f)
+  (define x 1)
+  (displayln "foo")
+  (begin0 x
+    (displayln "bar")))
+------------------------------
+
+
 test: "redundant let bindings can be removed"
 ------------------------------
 (define x 1)

--- a/default-recommendations/let-binding-suggestions.rkt
+++ b/default-recommendations/let-binding-suggestions.rkt
@@ -86,16 +86,19 @@
 
 
 (define-definition-context-refactoring-rule begin0-let-to-define-begin0
-  #:description "This `let` expression can be pulled up into a `define` expression."
+  #:description
+  "The `let` expression in this `begin0` form can be extracted into the surrounding definition\
+ context."
   #:literals (begin0 let)
   (~seq body-before ...
         (begin0
-            (~and original-let (let ([nested-id:id nested-expr:expr]) result-expr:expr))
+            (~and original-let (let ([nested-id:id nested-expr:expr]) let-body ... result-expr:expr))
           body-after ...))
   #:when (not
           (set-member? (syntax-bound-identifiers #'(body-before ... body-after ...)) #'nested-id))
   (body-before ...
    (define nested-id nested-expr)
+   let-body ...
    (begin0 (~replacement result-expr #:original original-let) body-after ...)))
 
 


### PR DESCRIPTION
Closes #405. Also adds a rule for flattening `begin` when it's already inside a definition context.