### PR TITLE
Remove non-lambda `positive?` and `negative?` rules

### DIFF
--- a/default-recommendations/numeric-shortcuts-test.rkt
+++ b/default-recommendations/numeric-shortcuts-test.rkt
@@ -21,22 +21,6 @@ test: "lambda equivalent to sub1 refactorable to sub1"
 - (map sub1 (list 1 2 3))
 
 
-test: "comparison equivalent to positive? refactorable to positive?"
-- (> 42 0)
-- (< 0 42)
-- (not (<= 42 0))
-- (not (>= 0 42))
-- (positive? 42)
-
-
-test: "comparison equivalent to negative? refactorable to negative?"
-- (< 42 0)
-- (> 0 42)
-- (not (>= 42 0))
-- (not (<= 0 42))
-- (negative? 42)
-
-
 test: "lambda equivalent to positive? refactorable to positive?"
 - (filter (λ (x) (> x 0)) (list -2 -1 0 1 2))
 - (filter (λ (x) (< 0 x)) (list -2 -1 0 1 2))

--- a/default-recommendations/numeric-shortcuts.rkt
+++ b/default-recommendations/numeric-shortcuts.rkt
@@ -34,16 +34,6 @@
   sub1)
 
 
-(define-refactoring-rule zero-comparison-to-positive?
-  #:description "This expression is equivalent to calling the `positive?` predicate."
-  #:literals (< > <= >= not)
-  (~or (> e:expr 0)
-       (< 0 e:expr)
-       (not (<= e:expr 0))
-       (not (>= 0 e:expr)))
-  (positive? e))
-
-
 (define-refactoring-rule zero-comparison-lambda-to-positive?
   #:description "This lambda function is equivalent to the built-in `positive?` predicate."
   #:literals (< > <= >= not)
@@ -54,16 +44,6 @@
                                   (not (>= 0 x2:id))))
   #:when (free-identifier=? #'x1 #'x2)
   positive?)
-
-
-(define-refactoring-rule zero-comparison-to-negative?
-  #:description "This expression is equivalent to calling the `negative?` predicate."
-  #:literals (< > <= >= not)
-  (~or (< e:expr 0)
-       (> 0 e:expr)
-       (not (>= e:expr 0))
-       (not (<= 0 e:expr)))
-  (negative? e))
 
 
 (define-refactoring-rule zero-comparison-lambda-to-negative?
@@ -98,6 +78,4 @@
            single-argument-plus-to-identity
            sub1-lambda-to-sub1
            zero-comparison-lambda-to-negative?
-           zero-comparison-lambda-to-positive?
-           zero-comparison-to-negative?
-           zero-comparison-to-positive?))
+           zero-comparison-lambda-to-positive?))


### PR DESCRIPTION
These just aren't worth it.