### PR TITLE
Rework macro expander integration

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -19,6 +19,7 @@
         "fancy-app"
         "fmt"
         "guard"
+        "macro-debugger-text-lib"
         "rackunit-lib"
         "rebellion"))
 

--- a/private/expander.rkt
+++ b/private/expander.rkt
@@ -1,0 +1,21 @@
+#lang racket/base
+
+
+(require macro-debugger/model/debug
+         racket/pretty
+         rebellion/type/record)
+
+
+(define-record-type expansion-history (original expanded steps))
+(define-record-type expansion-step (input output local-expansions))
+
+
+(define (expand-with-history stx)
+  (define derivation-tree (trace stx expand))
+  (expansion-history #:original (node-z1 derivation-tree)
+                     #:expanded (node-z2 derivation-tree)
+                     #:steps (vector derivation-tree)))
+
+
+(module+ main
+  (pretty-print (expand-with-history #'(module foo racket (lambda (x) (add1 x))))))


### PR DESCRIPTION
This is a work-in-progress attempt to give Resyntax better visibility into what happened during macro expansion, specifically by reusing the macro debugger's parsed representation of the expander's logged event stream. This should eventually give Resyntax the ability to tell when something is being locally expanded instead of normally expanded, when an identifier is being resolved for static info (see #153 for an example use case).