### PR TITLE
Add `deprecation-migrations` rules

### DIFF
--- a/default-recommendations.rkt
+++ b/default-recommendations.rkt
@@ -12,6 +12,7 @@
                resyntax/default-recommendations/console-io-suggestions
                resyntax/default-recommendations/contract-shortcuts
                resyntax/default-recommendations/definition-shortcuts
+               resyntax/default-recommendations/deprecation-migrations
                resyntax/default-recommendations/file-io-suggestions
                resyntax/default-recommendations/for-loop-shortcuts
                resyntax/default-recommendations/function-definition-shortcuts
@@ -44,6 +45,7 @@
          resyntax/default-recommendations/console-io-suggestions
          resyntax/default-recommendations/contract-shortcuts
          resyntax/default-recommendations/definition-shortcuts
+         resyntax/default-recommendations/deprecation-migrations
          resyntax/default-recommendations/file-io-suggestions
          resyntax/default-recommendations/for-loop-shortcuts
          resyntax/default-recommendations/function-definition-shortcuts
@@ -76,6 +78,7 @@
             console-io-suggestions
             contract-shortcuts
             definition-shortcuts
+            deprecation-migrations
             file-io-suggestions
             for-loop-shortcuts
             function-definition-shortcuts

--- a/default-recommendations/deprecation-migrations-test.rkt
+++ b/default-recommendations/deprecation-migrations-test.rkt
@@ -1,0 +1,26 @@
+#lang resyntax/test
+
+
+require: resyntax/default-recommendations deprecation-migrations
+
+
+header:
+------------------------------
+#lang racket/base
+(require resyntax/deprecated-alias-macro)
+------------------------------
+
+
+test: "use of deprecated alias refactorable to new name"
+------------------------------
+(define (a) 1)
+(provide b)
+(define-deprecated-alias b a)
+(b)
+------------------------------
+------------------------------
+(define (a) 1)
+(provide b)
+(define-deprecated-alias b a)
+(a)
+------------------------------

--- a/default-recommendations/deprecation-migrations.rkt
+++ b/default-recommendations/deprecation-migrations.rkt
@@ -1,0 +1,51 @@
+#lang racket/base
+
+
+(require racket/contract/base)
+
+
+(provide
+ (contract-out
+  [deprecation-migrations refactoring-suite?]))
+
+
+(require racket/class
+         resyntax/base
+         resyntax/deprecated-alias
+         syntax/parse)
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(define (resyntax-phase1-eval compile-time-expression-stx #:quote-syntax? [quote-syntax? #false])
+  (namespace-require 'syntax/macro-testing)
+  (namespace-require '(for-syntax racket/base))
+  (if quote-syntax?
+      (eval `(phase1-eval ,(syntax->datum compile-time-expression-stx) #:quote quote-syntax))
+      (eval `(phase1-eval ,(syntax->datum compile-time-expression-stx)))))
+
+
+(define-refactoring-rule inline-deprecated-alias
+  #:description "This form has been renamed. Use the new name instead of the deprecated alias."
+
+  (alias-id:id . tail)
+
+  #:do [(namespace-require '(for-syntax resyntax/deprecated-alias))]
+  #:when (resyntax-phase1-eval
+          #'(let-values ([(immediate _)
+                          (syntax-local-value/immediate #'alias-id (λ () (values #false #false)))])
+              (deprecated-alias? immediate)))
+  #:do [(define target-id-symbol
+          (resyntax-phase1-eval
+           #'(let-values ([(immediate _)
+                           (syntax-local-value/immediate #'alias-id
+                                                         (λ () (values #false #false)))])
+               (deprecated-alias-target immediate))))]
+  #:with target-id (datum->syntax #'alias-id target-id-symbol)
+
+  (target-id . tail))
+
+
+(define-refactoring-suite deprecation-migrations
+  #:rules (inline-deprecated-alias))


### PR DESCRIPTION
This is a work-in-progress attempt to automatically refactor uses of aliases defined with `define-deprecated-alias`. Closes #234, eventually.