### PR TITLE
Add whole-module analyzer system

### DIFF
--- a/private/analyzer.rkt
+++ b/private/analyzer.rkt
@@ -1,0 +1,35 @@
+#lang racket/base
+
+
+(require racket/contract/base)
+
+
+(provide
+ (contract-out
+  [expansion-analyzer? (-> any/c boolean?)]
+  [make-expansion-analyzer
+   (->* ((-> syntax? syntax-property-bundle?)) (#:name (and/c symbol? symbol-interned?))
+        expansion-analyzer?)]
+  [expansion-analyze (-> expansion-analyzer? syntax? syntax-property-bundle?)]))
+
+
+(require rebellion/custom-write
+         resyntax/private/syntax-property-bundle)
+
+
+;@----------------------------------------------------------------------------------------------------
+
+
+(struct expansion-analyzer (name implementation)
+  #:omit-define-syntaxes
+  #:constructor-name constructor:expansion-analyzer
+  #:property prop:object-name (struct-field-index name)
+  #:property prop:custom-write (make-named-object-custom-write 'expansion-analyzer))
+
+
+(define (make-expansion-analyzer implementation #:name [name #false])
+  (constructor:expansion-analyzer name implementation))
+
+
+(define (expansion-analyze analyzer expanded-syntax)
+  ((expansion-analyzer-implementation analyzer) expanded-syntax))

--- a/private/syntax-property-bundle.rkt
+++ b/private/syntax-property-bundle.rkt
@@ -11,16 +11,26 @@
   [syntax-property-bundle? (-> any/c boolean?)]
   [syntax-property-bundle-as-map (-> syntax-property-bundle? immutable-sorted-map?)]
   [syntax-property-bundle-entries (-> syntax-property-bundle? (sequence/c syntax-property-entry?))]
+  [syntax-property-bundle-get-property (-> syntax-property-bundle? syntax-path? any/c any/c)]
+  [syntax-property-bundle-get-immediate-properties
+   (-> syntax-property-bundle? syntax-path? immutable-hash?)]
+  [syntax-property-bundle-get-all-properties
+   (-> syntax-property-bundle? syntax-path? syntax-property-bundle?)]
   [sequence->syntax-property-bundle (-> (sequence/c syntax-property-entry?) syntax-property-bundle?)]
   [into-syntax-property-bundle (reducer/c syntax-property-entry? syntax-property-bundle?)]
+  [property-hashes-into-syntax-property-bundle
+   (reducer/c (entry/c syntax-path? immutable-hash?) syntax-property-bundle?)]
   [syntax-add-all-properties (-> syntax? syntax-property-bundle? syntax?)]))
 
 
-(require racket/match
+(require guard
+         racket/match
+         racket/mutability
          racket/sequence
          racket/stream
+         rebellion/base/range
          rebellion/collection/entry
-         rebellion/collection/hash
+         (except-in rebellion/collection/hash mutable-hash? immutable-hash?)
          rebellion/collection/sorted-map
          rebellion/streaming/reducer
          rebellion/streaming/transducer
@@ -53,6 +63,12 @@
       (match-define (syntax-property-entry path k v) prop-entry)
       (entry path (entry k v))))
    (grouping into-hash)
+   #:into (reducer-map (into-sorted-map syntax-path<=>) #:range constructor:syntax-property-bundle)))
+
+
+(define property-hashes-into-syntax-property-bundle
+  (into-transduced
+   (filtering-values (λ (prop-hash) (not (hash-empty? prop-hash))))
    #:into (reducer-map (into-sorted-map syntax-path<=>) #:range constructor:syntax-property-bundle)))
 
 
@@ -93,7 +109,104 @@
                  #:into into-syntax-property-bundle))
     (define expected
       (syntax-property-bundle term-01-quoted-prop term-02-quoted-prop term-03-quoted-prop))
+    (check-equal? actual expected))
+
+  (test-case "property-hashes-into-syntax-property-bundle"
+    (define prop-hashes
+      (list (entry (syntax-path (list 0 1)) (hash 'foo 1))
+                       (entry (syntax-path (list 0 2)) (hash 'bar 2 'baz 3))
+                       (entry (syntax-path (list 0 3)) (hash))))
+
+    (define actual (transduce prop-hashes #:into property-hashes-into-syntax-property-bundle))
+
+    (define expected
+      (syntax-property-bundle
+       (syntax-property-entry (syntax-path (list 0 1)) 'foo 1)
+       (syntax-property-entry (syntax-path (list 0 2)) 'bar 2)
+       (syntax-property-entry (syntax-path (list 0 2)) 'baz 3)))
     (check-equal? actual expected)))
+
+
+(define (syntax-property-bundle-get-property prop-bundle path key)
+  (define props-at-path (sorted-map-get (syntax-property-bundle-as-map prop-bundle) path (hash)))
+
+  (define (fail)
+    (raise-arguments-error
+     'syntax-property-bundle-get-property
+     "no property value for given key at given path"
+     "path" path
+     "property key" key
+     "properties at path" props-at-path))
+
+  (hash-ref props-at-path key fail))
+
+
+(module+ test
+  (test-case "syntax-property-bundle-get-property"
+
+    (test-case "bundle has entry for key and path"
+      (define path (syntax-path (list 1 2 3)))
+      (define props (syntax-property-bundle (syntax-property-entry path 'foo 42)))
+      (check-equal? (syntax-property-bundle-get-property props path 'foo) 42))
+
+    (test-case "empty bundle"
+      (define path (syntax-path (list 1 2 3)))
+
+      (define thrown
+        (with-handlers ([any/c values])
+          (syntax-property-bundle-get-property (syntax-property-bundle) path 'foo)
+          #false))
+
+      (check-pred exn:fail:contract? thrown)
+      (check-regexp-match #rx"syntax-property-bundle-get-property:" (exn-message thrown))
+      (check-regexp-match #rx"path:" (exn-message thrown))
+      (check-regexp-match #rx"property key: 'foo" (exn-message thrown))
+      (check-regexp-match #rx"properties at path: '#hash()" (exn-message thrown)))))
+
+
+(define (syntax-property-bundle-get-immediate-properties prop-bundle path)
+  (sorted-map-get (syntax-property-bundle-as-map prop-bundle) path (hash)))
+
+
+(module+ test
+  (test-case "syntax-property-bundle-get-immediate-properties"
+
+    (test-case "bundle has entry for path"
+      (define path (syntax-path (list 1 2 3)))
+      (define props
+        (syntax-property-bundle
+         (syntax-property-entry path 'foo 42)
+         (syntax-property-entry path 'bar #true)
+         (syntax-property-entry path 'baz #false)))
+
+      (define actual (syntax-property-bundle-get-immediate-properties props path))
+
+      (check-equal? actual (hash 'foo 42 'bar #true 'baz #false)))
+
+    (test-case "empty bundle"
+      (define path (syntax-path (list 1 2 3)))
+      (define actual (syntax-property-bundle-get-immediate-properties (syntax-property-bundle) path))
+      (check-equal? actual (hash)))))
+
+
+(define/guard (syntax-property-bundle-get-all-properties prop-bundle path)
+  (guard (nonempty-syntax-path? path) #:else prop-bundle)
+  (define next-neighbor (syntax-path-next-neighbor path))
+  (define path-range
+    (if next-neighbor
+        (closed-open-range path next-neighbor #:comparator syntax-path<=>)
+        (at-least-range path)))
+  (define submap (sorted-submap (syntax-property-bundle-as-map prop-bundle) path-range))
+  (define new-map
+    (transduce (in-sorted-map submap)
+               (mapping-keys (λ (submap-path) (syntax-path-remove-prefix submap-path path)))
+               #:into (into-sorted-map syntax-path<=>)))
+  (constructor:syntax-property-bundle new-map))
+
+
+(module+ test
+  (test-case "syntax-property-bundle-get-all-properties"
+    (void)))
 
 
 (define (syntax-property-bundle-entries prop-bundle)


### PR DESCRIPTION
Supersedes #514. Currently, only a single hard-coded analyzer is used, but this system is easily extendable to multiple hard-coded analyzers. Bundling analyzers with refactoring suites in the future is also possible, with a bit more work.

There's a TODO or two left to implement in here, but I want to get this merged and functioning before dealing with them.