### PR TITLE
Reformat single-line clauses in `let-to-define`

### DIFF
--- a/default-recommendations/let-binding-suggestions-test.rkt
+++ b/default-recommendations/let-binding-suggestions-test.rkt
@@ -684,3 +684,37 @@ test: "redundant let bindings can be removed"
 (define x 1)
 (* x 2)
 ------------------------------
+
+
+test: "single-line cond clause with let should be reformatted when refactoring to define"
+------------------------------
+(define (f x)
+  (cond
+    [(number? x) (let ([y 42]) (+ x y))]
+    [else 'else]))
+==============================
+(define (f x)
+  (cond
+    [(number? x)
+     (define y 42)
+     (+ x y)]
+    [else 'else]))
+------------------------------
+
+
+test: "single-line match clause with let should be reformatted when refactoring to define"
+------------------------------
+(require racket/match)
+(define (f x)
+  (match x
+    [(? number? x) (let ([y 42]) (+ x y))]
+    [_ 'else]))
+==============================
+(require racket/match)
+(define (f x)
+  (match x
+    [(? number? x)
+     (define y 42)
+     (+ x y)]
+    [_ 'else]))
+------------------------------

--- a/default-recommendations/let-binding-suggestions.rkt
+++ b/default-recommendations/let-binding-suggestions.rkt
@@ -10,6 +10,7 @@
 
 
 (require (for-syntax racket/base)
+         racket/list
          racket/set
          rebellion/private/static-name
          resyntax/base
@@ -42,7 +43,10 @@
   #:description
   "Internal definitions are recommended instead of `let` expressions, to reduce nesting."
   (~seq leading-body ... let-expression:refactorable-let-expression)
-  #:with (replacement ...) #'(~focus-replacement-on (let-expression.refactored ...))
+  #:with (replacement ...)
+  (if (empty? (attribute leading-body))
+      (attribute let-expression.refactored)
+      #'(~focus-replacement-on (let-expression.refactored ...)))
   (leading-body ... replacement ...))
 
 


### PR DESCRIPTION
Fixes the issue observed in racket/typed-racket#1463.