### PR TITLE
Rework identifier usage analysis

### DIFF
--- a/default-recommendations/analyzers/identifier-usage-test.rkt
+++ b/default-recommendations/analyzers/identifier-usage-test.rkt
@@ -1,0 +1,66 @@
+#lang resyntax/test
+
+
+require: resyntax/default-recommendations default-recommendations
+header: - #lang racket/base
+
+
+analysis-test: "unused module-level variable"
+- (define a 1)
+@inspect - a
+@property usage-count
+@assert 0
+
+
+analysis-test: "once-used module-level variable"
+--------------------
+(define a 1)
+(void a)
+--------------------
+@within - (define a 1)
+@inspect - a
+@property usage-count
+@assert 1
+
+
+analysis-test: "thrice-used module-level variable"
+--------------------
+(define a 1)
+(void a a a)
+--------------------
+@within - (define a 1)
+@inspect - a
+@property usage-count
+@assert 3
+
+
+analysis-test: "unused let-bound variable"
+--------------------
+(let ([a 1])
+  (void))
+--------------------
+@inspect - a
+@property usage-count
+@assert 0
+
+
+analysis-test: "once-used let-bound variable"
+--------------------
+(let ([a 1])
+  (void a))
+--------------------
+@within - [a 1]
+@inspect - a
+@property usage-count
+@assert 1
+
+
+analysis-test: "thrice-used let-bound variable"
+--------------------
+(let ([a 1])
+  (void a a a))
+--------------------
+@within - [a 1]
+@inspect - a
+@property usage-count
+@assert 3

--- a/default-recommendations/analyzers/identifier-usage.rkt
+++ b/default-recommendations/analyzers/identifier-usage.rkt
@@ -294,7 +294,11 @@
 
 
 (define (phase-binding-table bound-ids used-ids #:phase phase)
-  (for*/fold ([map (make-immutable-free-id-table #:phase phase)])
+  (define initial-map
+    (for/fold ([map (make-immutable-free-id-table #:phase phase)])
+              ([bound bound-ids])
+      (free-id-table-set map bound '())))
+  (for*/fold ([map initial-map])
              ([bound bound-ids]
               [used used-ids]
               #:when (free-identifier=? bound used))
@@ -327,36 +331,5 @@
                  (λ (id-table)
                    (for/stream ([(bound-id usages) (in-free-id-table id-table)])
                      (define exp-path (syntax-property bound-id 'expanded-path))
-                     (syntax-property-entry exp-path 'identifier-usages usages))))
+                     (syntax-property-entry exp-path 'usage-count (length usages)))))
                 #:into into-syntax-property-bundle))))
-
-
-(module+ test
-  (test-case "identifier-usage-analyzer"
-    ;; Arrange
-    (define stx
-      #'(module foo racket/base
-          (let ([x 42] [y 42])
-            (+ x y))))
-    (define expanded
-      (parameterize ([current-namespace (make-base-namespace)])
-        (expand stx)))
-    (define expanded-x-path (syntax-path (treelist 3 2 2 2 1 0 0 0)))
-    (define expanded-y-path (syntax-path (treelist 3 2 2 2 1 1 0 0)))
-    (check-equal? (syntax->datum (syntax-ref expanded expanded-x-path)) 'x)
-    (check-equal? (syntax->datum (syntax-ref expanded expanded-y-path)) 'y)
-    (define x-binding-clause-path (syntax-path-parent (syntax-path-parent expanded-x-path)))
-    (define y-binding-clause-path (syntax-path-parent (syntax-path-parent expanded-y-path)))
-    (check-equal? (syntax->datum (syntax-ref expanded x-binding-clause-path)) '[(x) '42])
-    (check-equal? (syntax->datum (syntax-ref expanded y-binding-clause-path)) '[(y) '42])
-
-    ;; Act
-    (define props (expansion-analyze identifier-usage-analyzer expanded))
-    (define prop-map (syntax-property-bundle-as-map props))
-
-    ;; Assert
-    (define expected-keys (sorted-set expanded-x-path expanded-y-path #:comparator syntax-path<=>))
-    (check-equal? (sorted-map-keys prop-map) expected-keys)
-    (check-equal? (length (hash-ref (sorted-map-get prop-map expanded-x-path) 'identifier-usages)) 1)
-    (check-equal? (length (hash-ref (sorted-map-get prop-map expanded-y-path) 'identifier-usages))
-                  1)))

--- a/default-recommendations/definition-shortcuts.rkt
+++ b/default-recommendations/definition-shortcuts.rkt
@@ -36,9 +36,7 @@
   #:literals (define)
   (~seq body-before ... (~and definition (define id1:id expr)) id2:id)
   #:when (free-identifier=? #'id1 #'id2)
-  #:when (match (syntax-property #'id1 'identifier-usages)
-           [(list _) #true]
-           [_ #false])
+  #:when (equal? (syntax-property #'id1 'usage-count) 1)
   #:with replacement #'(~replacement expr #:original-splice (definition id2))
   #:with focused (if (empty? (attribute body-before))
                      #'replacement

--- a/default-recommendations/for-loop-shortcuts.rkt
+++ b/default-recommendations/for-loop-shortcuts.rkt
@@ -579,7 +579,7 @@ return just that result."
   #:literals (in-hash)
   (for-id:id (clause-before ... [(key:id value:id) (in-hash hash-expr)] clause-after ...) body ...)
   #:when ((literal-set->predicate simple-for-loops) (attribute for-id))
-  #:when (empty? (or (syntax-property #'value 'identifier-usages) '()))
+  #:when (equal? (syntax-property #'value 'usage-count) 0)
   (for-id (clause-before ... [key (in-hash-keys hash-expr)] clause-after ...) body ...))
 
 
@@ -588,7 +588,7 @@ return just that result."
   #:literals (in-hash)
   (for-id:id (clause-before ... [(key:id value:id) (in-hash hash-expr)] clause-after ...) body ...)
   #:when ((literal-set->predicate simple-for-loops) (attribute for-id))
-  #:when (empty? (or (syntax-property #'key 'identifier-usages) '()))
+  #:when (equal? (syntax-property #'key 'usage-count) 0)
   (for-id (clause-before ... [value (in-hash-values hash-expr)] clause-after ...) body ...))
 
 

--- a/default-recommendations/function-definition-shortcuts.rkt
+++ b/default-recommendations/function-definition-shortcuts.rkt
@@ -156,7 +156,7 @@
   #:when (oneline-syntax? (attribute default-expr))
   #:when (free-identifier=? (attribute rest-args) (attribute rest-args2))
   #:when (free-identifier=? (attribute rest-args) (attribute rest-args3))
-  #:when (equal? (length (syntax-property (attribute rest-args) 'identifier-usages)) 2)
+  #:when (equal? (syntax-property (attribute rest-args) 'usage-count) 2)
 
   (define (f arg ... [optional-arg default-expr])
     body ...))

--- a/default-recommendations/private/let-binding.rkt
+++ b/default-recommendations/private/let-binding.rkt
@@ -132,7 +132,7 @@
 
 
 (define (unused-id? id)
-  (empty? (or (syntax-property id 'identifier-usages) '())))
+  (equal? (syntax-property id 'usage-count) 0))
 
 
 (define (identifier-would-self-shadow? id rhs-id #:full-right-hand-side rhs)

--- a/default-recommendations/unused-binding-suggestions.rkt
+++ b/default-recommendations/unused-binding-suggestions.rkt
@@ -28,7 +28,7 @@
 (define-definition-context-refactoring-rule unused-definition
   #:description "This definition is not used."
   (~seq before ... definition:side-effect-free-definition first-after remaining-after ...)
-  #:when (empty? (or (syntax-property (attribute definition.id) 'identifier-usages) '()))
+  #:when (equal? (syntax-property (attribute definition.id) 'usage-count) 0)
   (before ...
    (~focus-replacement-on (~replacement first-after #:original-splice (definition first-after)))
    remaining-after ...))

--- a/private/source.rkt
+++ b/private/source.rkt
@@ -55,9 +55,9 @@
          rebellion/collection/vector/builder
          rebellion/streaming/transducer
          rebellion/type/record
+         resyntax/default-recommendations/analyzers/identifier-usage
          resyntax/default-recommendations/analyzers/ignored-result-values
          resyntax/private/analyzer
-         resyntax/private/fully-expanded-syntax
          resyntax/private/linemap
          resyntax/private/logger
          resyntax/private/string-indent


### PR DESCRIPTION
The analyzer now reports just a count of usages, rather than a list of identifiers. That's all any of Resyntax's rules need anyway, and it makes writing test cases for the analyzer much easier.