### PR TITLE
Remove `require:` from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-rule-request.yaml
+++ b/.github/ISSUE_TEMPLATE/new-rule-request.yaml
@@ -16,7 +16,6 @@ body:
     description: Write a [Resyntax test case](https://docs.racket-lang.org/resyntax/Testing_Refactoring_Rules.html) demonstrating how this rule should transform code.
     value: |
       #lang resyntax/test
-      require: resyntax/default-recommendations default-recommendations
 
       test: "original code should be refactorable to new code"
       --------------------

--- a/.github/ISSUE_TEMPLATE/unwanted-suggestion-report.yaml
+++ b/.github/ISSUE_TEMPLATE/unwanted-suggestion-report.yaml
@@ -18,7 +18,6 @@ body:
     description: What code did Resyntax make an unwanted suggestion about? Put the code inside this test case.
     value: |
       #lang resyntax/test
-      require: resyntax/default-recommendations default-recommendations
 
       test: "this code should not be refactored"
       --------------------


### PR DESCRIPTION
The `default-recommendations` suite is used by default now.