### PR TITLE
Split new `no-change-test:` statement out of `test:`

### DIFF
--- a/default-recommendations/boolean-shortcuts-test.rkt
+++ b/default-recommendations/boolean-shortcuts-test.rkt
@@ -13,7 +13,7 @@ test: "nested ors can be flattened"
 - (or 1 2 3 4)
 
 
-test: "flat ors can't be flattened"
+no-change-test: "flat ors can't be flattened"
 - (or 1 2 3)
 
 
@@ -27,7 +27,7 @@ test: "deeply nested ors can be flattened in one pass"
 - (or 1 2 3 4 5 6)
 
 
-test: "multiline nested ors can't be flattened"
+no-change-test: "multiline nested ors can't be flattened"
 ------------------------------
 (or 1
     (or 2 3))
@@ -39,7 +39,7 @@ test: "nested ands can be flattened"
 - (and 1 2 3 4)
 
 
-test: "flat ands can't be flattened"
+no-change-test: "flat ands can't be flattened"
 - (and 1 2 3)
 
 
@@ -53,7 +53,7 @@ test: "deeply nested ands can be flattened in one pass"
 - (and 1 2 3 4 5 6)
 
 
-test: "multiline nested ands can't be flattened"
+no-change-test: "multiline nested ands can't be flattened"
 ------------------------------
 (and 1
      (and 2 3))
@@ -75,7 +75,8 @@ test: "using if to convert a boolean expression to a boolean can be removed"
 - (string? "foo")
 
 
-test: "using if to convert a boolean expression to a boolean can't be removed when if is rebound"
+no-change-test:
+"using if to convert a boolean expression to a boolean can't be removed when if is rebound"
 ------------------------------
 (define (if a b c)
   (displayln "You thought I was an if expression? Fool!"))

--- a/default-recommendations/class-shortcuts-test.rkt
+++ b/default-recommendations/class-shortcuts-test.rkt
@@ -21,7 +21,7 @@ test: "nested send expressions refactorable to flat send+ expression"
 --------------------
 
 
-test: "two-method nested send expression not refactorable to send+"
+no-change-test: "two-method nested send expression not refactorable to send+"
 --------------------
 (define (f obj x y)
   (send (send obj m1 x) m2 y))
@@ -48,7 +48,7 @@ test: "instantiate without by-position arguments refactorable to new"
 --------------------
 
 
-test: "instantiate without any arguments not refactorable"
+no-change-test: "instantiate without any arguments not refactorable"
 --------------------
 (define (f cls)
   (instantiate cls ()))

--- a/default-recommendations/comparison-shortcuts-test.rkt
+++ b/default-recommendations/comparison-shortcuts-test.rkt
@@ -60,9 +60,10 @@ test: "two double comparisons with same subject refactorable to triple <= compar
 - (<= -10 x 10)
 
 
-test: "or-comparisons not refactorable (see https://github.com/jackfirth/resyntax/issues/144)"
+no-change-test:
+"or-comparisons not refactorable (see https://github.com/jackfirth/resyntax/issues/144)"
 - (or (< x 2) (> x 36))
 
 
-test: "mixed inclusive and exclusive comparisons not refactorable"
+no-change-test: "mixed inclusive and exclusive comparisons not refactorable"
 - (and (< x 10) (>= x -10))

--- a/default-recommendations/conditional-shortcuts-test.rkt
+++ b/default-recommendations/conditional-shortcuts-test.rkt
@@ -8,7 +8,7 @@ header:
 - #lang racket/base
 
 
-test: "if without nested ifs not refactorable"
+no-change-test: "if without nested ifs not refactorable"
 - (if 'cond 'then 'else)
 
 
@@ -326,7 +326,8 @@ test: "cond expressions with an always-throwing negated first branch can be refa
 ------------------------------
 
 
-test: "cond expressions with an always-throwing first branch (of multiple) can't be refactored"
+no-change-test:
+"cond expressions with an always-throwing first branch (of multiple) can't be refactored"
 ------------------------------
 (define (f condition1 condition2 condition3)
   (cond
@@ -509,7 +510,7 @@ test: "cond with nested else-cond with commented second clause can be flattened"
 ------------------------------
 
 
-test: "cond with nested cond in last clause without else can't be flattened"
+no-change-test: "cond with nested cond in last clause without else can't be flattened"
 ------------------------------
 (define (f a b last-condition)
   (cond
@@ -524,7 +525,7 @@ test: "cond with nested cond in last clause without else can't be flattened"
 ------------------------------
 
 
-test: "`if-else-false-to-and` is not refactorable when `and` is shadowed"
+no-change-test: "`if-else-false-to-and` is not refactorable when `and` is shadowed"
 ------------------------------
 (define (and x y) (list x y))
 (if 'a (println "true branch") #f)
@@ -968,19 +969,19 @@ test: "and with let can be refactored to cond with define"
 ------------------------------
 
 
-test: "and without let should not be refactored"
+no-change-test: "and without let should not be refactored"
 ------------------------------
 (and 'some-condition (* 42 2))
 ------------------------------
 
 
-test: "and with empty let should not be refactored"
+no-change-test: "and with empty let should not be refactored"
 ------------------------------
 (and 'some-condition (let () (* 42 2)))
 ------------------------------
 
 
-test: "and with more than two arguments should not be refactored"
+no-change-test: "and with more than two arguments should not be refactored"
 ------------------------------
 (and 'some-condition 'another-condition (let ([x 42]) (* x 2)))
 ------------------------------
@@ -1014,7 +1015,7 @@ test: "nested when with multiple body expressions can be merged"
 --------------------
 
 
-test: "when with multiple forms in outer body should not be merged"
+no-change-test: "when with multiple forms in outer body should not be merged"
 --------------------
 (define (f c1 c2)
   (when c1
@@ -1054,7 +1055,7 @@ test: "implicit else in ignored cond refactorable to explicit else void"
 --------------------
 
 
-test: "implicit else in used cond not refactorable to explicit else void"
+no-change-test: "implicit else in used cond not refactorable to explicit else void"
 ------------------------------
 (define (f c1 c2)
   (cond
@@ -1063,7 +1064,7 @@ test: "implicit else in used cond not refactorable to explicit else void"
 ------------------------------
 
 
-test: "cond with existing else clause not refactorable"
+no-change-test: "cond with existing else clause not refactorable"
 ------------------------------
 (define (f c1 c2)
   (cond

--- a/default-recommendations/contract-shortcuts-test.rkt
+++ b/default-recommendations/contract-shortcuts-test.rkt
@@ -16,7 +16,7 @@ test: "nested or/c contracts can be flattened"
 - (void (or/c 1 2 3 4))
 
 
-test: "flat or/c contracts can't be flattened"
+no-change-test: "flat or/c contracts can't be flattened"
 - (or/c 1 2 3)
 
 
@@ -30,7 +30,7 @@ test: "deeply nested or/c contracts can be flattened in one pass"
 - (void (or/c 1 2 3 4 5 6))
 
 
-test: "multiline nested or/c contracts can't be flattened"
+no-change-test: "multiline nested or/c contracts can't be flattened"
 ------------------------------
 (or/c 1
       (or/c 2 3))
@@ -42,7 +42,7 @@ test: "nested and/c contracts can be flattened"
 - (void (and/c 1 2 3 4))
 
 
-test: "flat and/c contracts can't be flattened"
+no-change-test: "flat and/c contracts can't be flattened"
 - (and/c 1 2 3)
 
 
@@ -56,7 +56,7 @@ test: "deeply nested and/c contracts can be flattened in one pass"
 - (void (and/c 1 2 3 4 5 6))
 
 
-test: "multiline nested and/c contracts can't be flattened"
+no-change-test: "multiline nested and/c contracts can't be flattened"
 ------------------------------
 (and/c 1
        (and/c 2 3))
@@ -90,7 +90,8 @@ test: "infix ->* contracts using #:rest (listof arg) can be replaced with -> and
 - (void (-> string? number? symbol? ... list?))
 
 
-test: "->* contracts using #:rest and optional arguments not refactorable to -> and ellipses"
+no-change-test:
+"->* contracts using #:rest and optional arguments not refactorable to -> and ellipses"
 - (void (->* () (string?) #:rest (listof symbol?) list?))
 
 

--- a/default-recommendations/definition-shortcuts-test.rkt
+++ b/default-recommendations/definition-shortcuts-test.rkt
@@ -115,7 +115,7 @@ test: "immediately returned variable definition can be inlined"
 ------------------------------
 
 
-test: "immediately returned function definition cannot be inlined"
+no-change-test: "immediately returned function definition cannot be inlined"
 ------------------------------
 (define (foo)
   (define (x)
@@ -124,7 +124,7 @@ test: "immediately returned function definition cannot be inlined"
 ------------------------------
 
 
-test: "immediately used variable definition cannot be inlined"
+no-change-test: "immediately used variable definition cannot be inlined"
 ------------------------------
 (define (foo)
   (define x 1)
@@ -132,7 +132,7 @@ test: "immediately used variable definition cannot be inlined"
 ------------------------------
 
 
-test: "immediately returned recursive definition cannot be inlined"
+no-change-test: "immediately returned recursive definition cannot be inlined"
 ------------------------------
 (define (foo)
   (define x (list (lambda () x)))
@@ -233,7 +233,7 @@ test: "begin0 in right hand side of variable definition can be removed"
 --------------------
 
 
-test: "begin0 in right hand side of function definition can't be removed"
+no-change-test: "begin0 in right hand side of function definition can't be removed"
 --------------------
 (define (foo)
   (define (x) (begin0 42 (displayln "foo")))

--- a/default-recommendations/file-io-suggestions-test.rkt
+++ b/default-recommendations/file-io-suggestions-test.rkt
@@ -27,5 +27,6 @@ test: "should migrate make-temporary-file with base-dir and 'directory to make-t
 - (void (make-temporary-directory #:base-dir #false))
 
 
-test: "should not migrate make-temporary-file without 'directory to make-temporary-directory"
+no-change-test:
+"should not migrate make-temporary-file without 'directory to make-temporary-directory"
 - (make-temporary-file #:copy-from #false)

--- a/default-recommendations/for-loop-shortcuts-test.rkt
+++ b/default-recommendations/for-loop-shortcuts-test.rkt
@@ -8,7 +8,7 @@ header:
 - #lang racket/base
 
 
-test: "map with short single-form body not refactorable"
+no-change-test: "map with short single-form body not refactorable"
 ------------------------------
 (define some-list (list 1 2 3))
 (map (λ (x) (* x 2)) some-list)
@@ -101,7 +101,7 @@ test: "map bytes->list to for/list in-bytes"
 ------------------------------
 
 
-test: "for-each with short single-form body not refactorable"
+no-change-test: "for-each with short single-form body not refactorable"
 ------------------------------
 (define some-list (list 1 2 3))
 (for-each (λ (x) (displayln x)) some-list)
@@ -194,7 +194,7 @@ test: "for-each bytes->list to for in-bytes"
 ------------------------------
 
 
-test: "hash-for-each with short single-body form not refactorable"
+no-change-test: "hash-for-each with short single-body form not refactorable"
 ------------------------------
 (define some-hash (hash 'a 1 'b 2))
 (hash-for-each some-hash (λ (k v) (displayln v)))
@@ -247,7 +247,7 @@ test: "hash-for-each with let expression refactorable to for with definitions"
 ------------------------------
 
 
-test: "build-list with short single-body form not refactorable"
+no-change-test: "build-list with short single-body form not refactorable"
 - (build-list 10 (λ (i) (* i 2)))
 
 
@@ -332,7 +332,7 @@ test: "for/and with or guarding complex expression to filter clause"
 ------------------------------
 
 
-test: "for/and with or guarding simple expression not refactorable"
+no-change-test: "for/and with or guarding simple expression not refactorable"
 ------------------------------
 (define some-list (list 3 "foo" 5 14 "bar" 10 6 "baz" 5 2))
 (for/and ([x (in-list some-list)])
@@ -381,7 +381,7 @@ test: "for*/fold building hash to for*/hash"
 ------------------------------
 
 
-test: "for/fold building hash can't be refactored when referring to hash"
+no-change-test: "for/fold building hash can't be refactored when referring to hash"
 ------------------------------
 (for/fold ([h (hash)])
           ([x (in-range 0 10)])
@@ -390,7 +390,7 @@ test: "for/fold building hash can't be refactored when referring to hash"
 ------------------------------
 
 
-test: "for*/fold building hash can't be refactored when referring to hash"
+no-change-test: "for*/fold building hash can't be refactored when referring to hash"
 ------------------------------
 (for*/fold ([h (hash)])
            ([x (in-range 0 10)])
@@ -587,7 +587,7 @@ test: "nested for forms can be flattened to a for* form"
 ------------------------------
 
 
-test: "non-nested for form isn't replaced by a for* form"
+no-change-test: "non-nested for form isn't replaced by a for* form"
 ------------------------------
 (for ([x (in-range 0 5)])
   (displayln x)
@@ -733,7 +733,7 @@ test: "append-map with for/list can be replaced by for*/list"
 ------------------------------------------------------------
 
 
-test: "append-map with multi-clause for/list can't be replaced by for*/list"
+no-change-test: "append-map with multi-clause for/list can't be replaced by for*/list"
 ------------------------------------------------------------
 (require racket/list)
 (append-map (λ (n)
@@ -782,7 +782,7 @@ test: "for-each and append-map can be replaced by for* with #:when"
 ------------------------------------------------------------
 
 
-test: "(apply append ...) with a multi-clause for loop can't be removed"
+no-change-test: "(apply append ...) with a multi-clause for loop can't be removed"
 ------------------------------------------------------------
 (define formulas
   (hash 'water (list 'hydrogen 'oxygen)
@@ -794,7 +794,7 @@ test: "(apply append ...) with a multi-clause for loop can't be removed"
 ------------------------------------------------------------
 
 
-test: "(apply append ...) with a multi-body for loop can't be removed"
+no-change-test: "(apply append ...) with a multi-body for loop can't be removed"
 ------------------------------------------------------------
 (define formulas
   (hash 'water (list 'hydrogen 'oxygen)
@@ -806,7 +806,7 @@ test: "(apply append ...) with a multi-body for loop can't be removed"
 ------------------------------------------------------------
 
 
-test: "(apply append ...) with a multi-body for* loop can't be removed"
+no-change-test: "(apply append ...) with a multi-body for* loop can't be removed"
 ------------------------------------------------------------
 (define formulas
   (hash 'water (list 'hydrogen 'oxygen)
@@ -896,11 +896,11 @@ test: "for/vector with in-range n gets #:length n"
 ------------------------------------------------------------
 
 
-test: "for/vector with literal end won't have #:length added"
+no-change-test: "for/vector with literal end won't have #:length added"
 - (for/vector ([i (in-range 0 10)]) i)
 
 
-test: "for/vector with expression end won't have #:length added"
+no-change-test: "for/vector with expression end won't have #:length added"
 ------------------------------------------------------------
 (define n 5)
 (define m 3)
@@ -908,14 +908,14 @@ test: "for/vector with expression end won't have #:length added"
 ------------------------------------------------------------
 
 
-test: "for/vector with non-zero start won't have #:length added"
+no-change-test: "for/vector with non-zero start won't have #:length added"
 ------------------------------------------------------------
 (define n 5)
 (for/vector ([i (in-range 2 n)]) i)
 ------------------------------------------------------------
 
 
-test: "for/vector with multiple clauses won't have #:length added"
+no-change-test: "for/vector with multiple clauses won't have #:length added"
 ------------------------------------------------------------
 (define n 5)
 (define m 3)
@@ -945,7 +945,7 @@ test: "in-hash refactorable to in-hash-values when only the value is used"
 --------------------
 
 
-test: "in-hash not refactorable to in-hash-keys when key and value both used"
+no-change-test: "in-hash not refactorable to in-hash-keys when key and value both used"
 --------------------
 (for ([(k v) (in-hash (hash 'a 1 'b 2 'c 3))])
   (displayln k)
@@ -1025,7 +1025,7 @@ test: "unused in-value clause refactorable to #:do clause"
 --------------------
 
 
-test: "used in-value clause not refactorable to #:do clause"
+no-change-test: "used in-value clause not refactorable to #:do clause"
 --------------------
 (for* ([a (in-range 0 3)]
        [b (in-value (* a 2))]

--- a/default-recommendations/function-definition-shortcuts-test.rkt
+++ b/default-recommendations/function-definition-shortcuts-test.rkt
@@ -61,7 +61,7 @@ test: "lambda variable definition with rest argument to function definition"
 ------------------------------
 
 
-test: "class lambda variable definition not refactorable"
+no-change-test: "class lambda variable definition not refactorable"
 ------------------------------
 (require racket/class)
 (class object%
@@ -82,7 +82,7 @@ test: "lambda function definition to function definition"
 ------------------------------
 
 
-test: "lambda function definition with closed-over expressions not refactorable"
+no-change-test: "lambda function definition with closed-over expressions not refactorable"
 ------------------------------
 (define (f a b c)
   (displayln a)
@@ -91,7 +91,7 @@ test: "lambda function definition with closed-over expressions not refactorable"
 ------------------------------
 
 
-test: "thunk function definition not refactorable (it's too terse)"
+no-change-test: "thunk function definition not refactorable (it's too terse)"
 ------------------------------
 (define (f a b c)
   (λ ()
@@ -99,7 +99,7 @@ test: "thunk function definition not refactorable (it's too terse)"
 ------------------------------
 
 
-test: "lambda variable definition with commented first body not refactorable (yet)"
+no-change-test: "lambda variable definition with commented first body not refactorable (yet)"
 ------------------------------
 (define f
   (λ (a)
@@ -159,7 +159,7 @@ test: "nested lambda function definition to function definition"
 ------------------------------
 
 
-test: "nested lambda variable with multiple multiline headers not refactorable"
+no-change-test: "nested lambda variable with multiple multiline headers not refactorable"
 ------------------------------
 (define f
   (λ (a
@@ -172,7 +172,7 @@ test: "nested lambda variable with multiple multiline headers not refactorable"
 ------------------------------
 
 
-test: "function with multiline header returning lambda not refactorable"
+no-change-test: "function with multiline header returning lambda not refactorable"
 ------------------------------
 (define (f a
            b
@@ -182,7 +182,7 @@ test: "function with multiline header returning lambda not refactorable"
 ------------------------------
 
 
-test: "function returning lambda with multiline header not refactorable"
+no-change-test: "function returning lambda with multiline header not refactorable"
 ------------------------------
 (define (f a)
   (λ (x
@@ -220,7 +220,7 @@ test: "case-lambda with default arg and required args"
 ------------------------------
 
 
-test: "case-lambda with default arg not refactorable when required args out of order"
+no-change-test: "case-lambda with default arg not refactorable when required args out of order"
 ------------------------------
 (define f
   (case-lambda
@@ -231,7 +231,7 @@ test: "case-lambda with default arg not refactorable when required args out of o
 ------------------------------
 
 
-test: "case-lambda with default arg not refactorable when default is a multiline expression"
+no-change-test: "case-lambda with default arg not refactorable when default is a multiline expression"
 ------------------------------
 (define f
   (case-lambda
@@ -309,7 +309,8 @@ test: "empty-checked rest args to optional arg"
 ------------------------------
 
 
-test: "empty-checked rest args not refactorable to optional arg when default expression is multiline"
+no-change-test:
+"empty-checked rest args not refactorable to optional arg when default expression is multiline"
 ------------------------------
 (define (foo a b . x*)
   (define x
@@ -322,7 +323,8 @@ test: "empty-checked rest args not refactorable to optional arg when default exp
 ------------------------------
 
 
-test: "empty-checked rest args not refactorable to optional arg when rest args used elsewhere"
+no-change-test:
+"empty-checked rest args not refactorable to optional arg when rest args used elsewhere"
 ------------------------------
 (define (foo a b . x*)
   (define x (if (null? x*) "default" (car x*)))

--- a/default-recommendations/gap-preservation-test.rkt
+++ b/default-recommendations/gap-preservation-test.rkt
@@ -38,7 +38,7 @@ test: "later comments preserved in splice when form inserted after first"
 -----------------------------------
 
 
-test: "not refactorable when comment dropped due to inserted form"
+no-change-test: "not refactorable when comment dropped due to inserted form"
 -----------------------------------
 (define (code insert-foo-second a b c)
   (insert-foo-second a

--- a/default-recommendations/hash-shortcuts-test.rkt
+++ b/default-recommendations/hash-shortcuts-test.rkt
@@ -20,7 +20,7 @@ test: "hash-ref with constant lambda can be simplified to hash-ref without lambd
 ------------------------------
 
 
-test: "hash-ref with non-constant lambda cannot be simplified to hash-ref without lambda"
+no-change-test: "hash-ref with non-constant lambda cannot be simplified to hash-ref without lambda"
 ------------------------------
 (define h (make-hash))
 (define k 'a)
@@ -42,7 +42,7 @@ test: "hash-ref! with constant lambda can be simplified to hash-ref! without lam
 ------------------------------
 
 
-test: "hash-ref! with non-constant lambda cannot be simplified to hash-ref! without lambda"
+no-change-test: "hash-ref! with non-constant lambda cannot be simplified to hash-ref! without lambda"
 ------------------------------
 (define h (make-hash))
 (define k 'a)
@@ -163,7 +163,7 @@ test: "hash-set! with hash-ref can be simplified to hash-update! without lambda"
 ------------------------------
 
 
-test: "hash-set! with hash-ref cannot be simplified when v would shadow"
+no-change-test: "hash-set! with hash-ref cannot be simplified when v would shadow"
 ------------------------------
 (define h (make-hash))
 (define k 'a)
@@ -261,7 +261,8 @@ test: "hash-ref and hash-set! with variable to hash-update! works with literal k
 ------------------------------
 
 
-test: "hash-ref and hash-set! with let cannot be simplified when key expressions are different"
+no-change-test:
+"hash-ref and hash-set! with let cannot be simplified when key expressions are different"
 ------------------------------
 (define (f h term other)
   (let ([sum (hash-ref! h (cadr term) 0)])
@@ -269,7 +270,8 @@ test: "hash-ref and hash-set! with let cannot be simplified when key expressions
 ------------------------------
 
 
-test: "hash-ref and hash-set! with define cannot be simplified when key expressions are different"
+no-change-test:
+"hash-ref and hash-set! with define cannot be simplified when key expressions are different"
 ------------------------------
 (define (f h term other)
   (define sum (hash-ref! h (cadr term) 0))
@@ -277,7 +279,8 @@ test: "hash-ref and hash-set! with define cannot be simplified when key expressi
 ------------------------------
 
 
-test: "hash-ref and hash-set! with let cannot be simplified when hash expressions are different"
+no-change-test:
+"hash-ref and hash-set! with let cannot be simplified when hash expressions are different"
 ------------------------------
 (define (f h1 h2 term)
   (let ([sum (hash-ref! h1 (cadr term) 0)])
@@ -285,7 +288,8 @@ test: "hash-ref and hash-set! with let cannot be simplified when hash expression
 ------------------------------
 
 
-test: "hash-ref and hash-set! with define cannot be simplified when hash expressions are different"
+no-change-test:
+"hash-ref and hash-set! with define cannot be simplified when hash expressions are different"
 ------------------------------
 (define (f h1 h2 term)
   (define sum (hash-ref! h1 (cadr term) 0))

--- a/default-recommendations/let-binding-suggestions-comment-test.rkt
+++ b/default-recommendations/let-binding-suggestions-comment-test.rkt
@@ -39,7 +39,7 @@ test: "let binding with commented second clause"
 ------------------------------
 
 
-test: "let binding with commented first clause not refactorable (yet)"
+no-change-test: "let binding with commented first clause not refactorable (yet)"
 ------------------------------
 (define (f)
   (let (;; The number one

--- a/default-recommendations/let-binding-suggestions-test.rkt
+++ b/default-recommendations/let-binding-suggestions-test.rkt
@@ -205,7 +205,7 @@ test: "multiple let*-values bindings"
 ------------------------------
 
 
-test: "self-shadowing let binding isn't refactorable"
+no-change-test: "self-shadowing let binding isn't refactorable"
 ------------------------------
 (define (f x)
   (let ([x (+ x 1)])
@@ -213,7 +213,7 @@ test: "self-shadowing let binding isn't refactorable"
 ------------------------------
 
 
-test: "self-shadowing let* binding isn't refactorable"
+no-change-test: "self-shadowing let* binding isn't refactorable"
 ------------------------------
 (define (f x)
   (let* ([x (+ x 1)])
@@ -221,7 +221,7 @@ test: "self-shadowing let* binding isn't refactorable"
 ------------------------------
 
 
-test: "self-shadowing let-values binding clause isn't refactorable"
+no-change-test: "self-shadowing let-values binding clause isn't refactorable"
 ------------------------------
 (define (f x)
   (let-values ([(x y) (values x 1)])
@@ -229,7 +229,7 @@ test: "self-shadowing let-values binding clause isn't refactorable"
 ------------------------------
 
 
-test: "self-shadowing let*-values binding clause isn't refactorable"
+no-change-test: "self-shadowing let*-values binding clause isn't refactorable"
 ------------------------------
 (define (f x)
   (let*-values ([(x y) (values x 1)])
@@ -265,7 +265,7 @@ test: "let* with later right-hand-sides referring to earlier bindings is refacto
 ------------------------------
 
 
-test: "let* with later bindings shadowing earlier right-hand-sides not refactorable"
+no-change-test: "let* with later bindings shadowing earlier right-hand-sides not refactorable"
 ------------------------------
 (define y 1)
 (define (f)
@@ -345,7 +345,7 @@ test: "partially used let-values binding at phase 1 refactorable to define-value
 ------------------------------
 
 
-test: "let forms with conflicting outer definitions not refactorable"
+no-change-test: "let forms with conflicting outer definitions not refactorable"
 ------------------------------
 (define (f)
   (define x 1)
@@ -354,7 +354,7 @@ test: "let forms with conflicting outer definitions not refactorable"
 ------------------------------
 
 
-test: "let forms with conflicting outer definitions at phase 1 not refactorable"
+no-change-test: "let forms with conflicting outer definitions at phase 1 not refactorable"
 ------------------------------
 (require (for-syntax racket/base))
 (begin-for-syntax
@@ -509,14 +509,14 @@ test: "let forms inside for loop bodies"
 ------------------------------
 
 
-test: "let forms at module level not refactorable to define"
+no-change-test: "let forms at module level not refactorable to define"
 ------------------------------
 (let ([x 1])
   (* x 2))
 ------------------------------
 
 
-test: "let forms at submodule level not refactorable to define"
+no-change-test: "let forms at submodule level not refactorable to define"
 ------------------------------
 (module+ test
   (let ([x 1])
@@ -532,7 +532,7 @@ test: "named lets which don't refer to the name are refactorable to unnamed lets
 ------------------------------
 
 
-test: "named lets which do refer to the name aren't refactorable to unnamed lets"
+no-change-test: "named lets which do refer to the name aren't refactorable to unnamed lets"
 ------------------------------
 (let loop ([x 1])
   (if (zero? x)
@@ -546,11 +546,12 @@ test: "let-values expressions with an immediate call are refactorable to call-wi
 - (call-with-values (λ () (values 1 2 3)) list)
 
 
-test: "let-values expressions with an immediate call with different order aren't refactorable"
+no-change-test:
+"let-values expressions with an immediate call with different order aren't refactorable"
 - (let-values ([(x y z) (values 1 2 3)]) (list z y x))
 
 
-test: "let binding with conflicting define inside"
+no-change-test: "let binding with conflicting define inside"
 ------------------------------
 (define (g)
   (let* ([x 1]
@@ -560,7 +561,7 @@ test: "let binding with conflicting define inside"
 ------------------------------
 
 
-test: "let binding with obfuscated conflicting define inside"
+no-change-test: "let binding with obfuscated conflicting define inside"
 ------------------------------
 (define (g)
   (let* ([x 'outer]
@@ -611,7 +612,7 @@ test:
 ------------------------------
 
 
-test: "variable definition with nested let binding of same name not refactorable"
+no-change-test: "variable definition with nested let binding of same name not refactorable"
 ------------------------------
 (define (f)
   (define y (let ([y 1]) (* y 2)))
@@ -619,7 +620,7 @@ test: "variable definition with nested let binding of same name not refactorable
 ------------------------------
 
 
-test: "variable definition with nested let binding of name bound later not refactorable"
+no-change-test: "variable definition with nested let binding of name bound later not refactorable"
 ------------------------------
 (define (f)
   (define y (let ([x 1]) (* x 2)))
@@ -628,7 +629,7 @@ test: "variable definition with nested let binding of name bound later not refac
 ------------------------------
 
 
-test: "variable definition with nested let binding of name bound earlier not refactorable"
+no-change-test: "variable definition with nested let binding of name bound earlier not refactorable"
 ------------------------------
 (define (f)
   (define x 5)
@@ -637,7 +638,8 @@ test: "variable definition with nested let binding of name bound earlier not ref
 ------------------------------
 
 
-test: "variable definition with nested let binding shadowing name used later not refactorable"
+no-change-test:
+"variable definition with nested let binding shadowing name used later not refactorable"
 ------------------------------
 (define x 5)
 (define (f)

--- a/default-recommendations/list-shortcuts-test.rkt
+++ b/default-recommendations/list-shortcuts-test.rkt
@@ -8,7 +8,7 @@ header:
 - #lang racket/base
 
 
-test: "car reverse of list not refactorable to last of list, due to imports (see issue #11)"
+no-change-test: "car reverse of list not refactorable to last of list, due to imports (see issue #11)"
 - (car (reverse (list 1 2 3)))
 
 
@@ -131,7 +131,7 @@ test: "unnecessary quasiquotation with constants refactorable to list"
 ------------------------------
 
 
-test: "quasiquotation with only constants not refactorable to list"
+no-change-test: "quasiquotation with only constants not refactorable to list"
 - `(1 2 3)
 
 
@@ -145,7 +145,7 @@ test: "unnecessary splicing quasiquotation refactorable to append"
 ------------------------------
 
 
-test: "splicing quasiquotation with other subterms not refactorable to append"
+no-change-test: "splicing quasiquotation with other subterms not refactorable to append"
 ------------------------------
 (define (f xs ys zs)
   `(a ,@xs b ,@ys c ,@zs d))
@@ -168,7 +168,7 @@ test: "ignored map expression refactorable to for-each"
 ------------------------------
 
 
-test: "used map expression not refactorable to for-each"
+no-change-test: "used map expression not refactorable to for-each"
 ------------------------------
 (define (f func xs ys zs)
   (map func xs ys zs))
@@ -239,7 +239,7 @@ test: "list of contiguous selections starting at first element to take"
 ------------------------------
 
 
-test: "list of only two contiguous selections not refactorable to take and drop"
+no-change-test: "list of only two contiguous selections not refactorable to take and drop"
 ------------------------------
 (require racket/list)
 (define vs (list 'foo 'bar 'baz 'blah 'zorp 'zoog 'karp))

--- a/default-recommendations/match-shortcuts-test.rkt
+++ b/default-recommendations/match-shortcuts-test.rkt
@@ -84,7 +84,8 @@ test: "single-clause match expressions inside cond can be replaced with match-de
 ------------------------------
 
 
-test: "single-clause match not migratable when pattern bindings conflict with surrounding context"
+no-change-test:
+"single-clause match not migratable when pattern bindings conflict with surrounding context"
 ------------------------------
 (define (foo x)
   (define a 42)
@@ -93,7 +94,7 @@ test: "single-clause match not migratable when pattern bindings conflict with su
 ------------------------------
 
 
-test: "single-clause match not migratable when pattern would bind subject expression"
+no-change-test: "single-clause match not migratable when pattern would bind subject expression"
 ------------------------------
 (define (foo x)
   (match x
@@ -155,7 +156,7 @@ test: "nested match patterns using ? with a lambda can be simplified with #:when
 ------------------------------
 
 
-test: "match patterns using ? with a lambda cannot be simplified when under ellipses"
+no-change-test: "match patterns using ? with a lambda cannot be simplified when under ellipses"
 ------------------------------
 (define (foo xs)
   (match xs
@@ -220,7 +221,7 @@ test: "root-level and pattern can be removed when it binds unused variable"
 ------------------------------
 
 
-test: "root-level and pattern not removed when not matching on a simple variable"
+no-change-test: "root-level and pattern not removed when not matching on a simple variable"
 ------------------------------
 (define (f lst)
   (match (car lst)
@@ -313,7 +314,7 @@ test: "single-clause match with if conditional should be refactored to match-def
 ------------------------------
 
 
-test: "match with if conditional and long pattern should not be refactored to use #:when"
+no-change-test: "match with if conditional and long pattern should not be refactored to use #:when"
 ------------------------------
 (define (f data)
   (match data

--- a/default-recommendations/require-and-provide-suggestions-test.rkt
+++ b/default-recommendations/require-and-provide-suggestions-test.rkt
@@ -43,7 +43,7 @@ test: "removing duplicate provided identifiers leaves other exports unchanged"
 ----------------------------------------
 
 
-test: "provide deduplication doesn't affect exports at different phases"
+no-change-test: "provide deduplication doesn't affect exports at different phases"
 ----------------------------------------
 (provide foo
          (for-syntax foo))
@@ -67,7 +67,7 @@ test: "require tidying sorts collection paths by name"
 
 
 
-test: "require tidying does nothing when collection paths already sorted by name"
+no-change-test: "require tidying does nothing when collection paths already sorted by name"
 ----------------------------------------
 (require racket/hash
          racket/list
@@ -121,14 +121,14 @@ test: "require tidying should move non-phase spec forms before relative paths"
 ----------------------------------------
 
 
-test: "require tidying of only non-phase spec forms should do nothing"
+no-change-test: "require tidying of only non-phase spec forms should do nothing"
 ----------------------------------------
 (require (only-in racket/list first)
          (only-in racket/hash hash-union))
 ----------------------------------------
 
 
-test: "require tidying shouldn't trigger when transformers are imported and used"
+no-change-test: "require tidying shouldn't trigger when transformers are imported and used"
 ----------------------------------------
 (require racket/require
          (multi-in racket (list set dict))
@@ -136,7 +136,8 @@ test: "require tidying shouldn't trigger when transformers are imported and used
 ----------------------------------------
 
 
-test: "require tidying shouldn't trigger when transformers are imported and used in nested specs"
+no-change-test:
+"require tidying shouldn't trigger when transformers are imported and used in nested specs"
 ----------------------------------------
 (require racket/require
          (prefix-in racket: (multi-in racket (list set dict)))

--- a/default-recommendations/shadowed-output-test.rkt
+++ b/default-recommendations/shadowed-output-test.rkt
@@ -13,14 +13,14 @@ header:
 ------------------------------
 
 
-test: "shadowed `or`: single-line de morgan's law"
+no-change-test: "shadowed `or`: single-line de morgan's law"
 ------------------------------
 (define (or x y z) (append x y z))
 (and (not 1) (not 2) (not 3))
 ------------------------------
 
 
-test: "shadowed `or`: multi-line de morgan's law"
+no-change-test: "shadowed `or`: multi-line de morgan's law"
 ------------------------------
 (define (or x y z) (append x y z))
 (and (not 1)
@@ -29,14 +29,14 @@ test: "shadowed `or`: multi-line de morgan's law"
 ------------------------------
 
 
-test: "shadowed `and`: single-line de morgan's law"
+no-change-test: "shadowed `and`: single-line de morgan's law"
 ------------------------------
 (define (and x y z) (list x y z))
 (or (not 1) (not 2) (not 3))
 ------------------------------
 
 
-test: "shadowed `and`: multi-line de morgan's law"
+no-change-test: "shadowed `and`: multi-line de morgan's law"
 ------------------------------
 (define (and x y z) (list x y z))
 (or (not 1)
@@ -45,14 +45,14 @@ test: "shadowed `and`: multi-line de morgan's law"
 ------------------------------
 
 
-test: "shadowed `not`: if then false else true"
+no-change-test: "shadowed `not`: if then false else true"
 ------------------------------
 (define (not b) (list 'not b))
 (if 4 #false #true)
 ------------------------------
 
 
-test: "shadowed `unless`: when not"
+no-change-test: "shadowed `unless`: when not"
 ------------------------------
 (define (unless c b) b)
 (when (not 'foo)
@@ -74,7 +74,7 @@ test: "shadowed `displayln`: when not -> unless is fine"
 ------------------------------
 
 
-test: "shadowed `when`: unless not"
+no-change-test: "shadowed `when`: unless not"
 ------------------------------
 (define (when c b) b)
 (unless (not 'foo)
@@ -96,14 +96,14 @@ test: "shadowed `displayln`: unless not -> when is fine"
 ------------------------------
 
 
-test: "shadowed `and`: single-line if-else-false-to-and"
+no-change-test: "shadowed `and`: single-line if-else-false-to-and"
 ------------------------------
 (define (and x y) (list x y))
 (if 'a (println "true branch") #f)
 ------------------------------
 
 
-test: "shadowed `and`: multi-line if-else-false-to-and"
+no-change-test: "shadowed `and`: multi-line if-else-false-to-and"
 ------------------------------
 (define (and x y) (list x y))
 (if 'a
@@ -139,7 +139,7 @@ test: "shadowed `println`: multi-line if-else-false-to-and is fine"
 ------------------------------
 
 
-test: "shadowed `for`: for-each with long single-form body"
+no-change-test: "shadowed `for`: for-each with long single-form body"
 ------------------------------
 (define (for lst f)
   (for-each f lst))
@@ -151,7 +151,7 @@ test: "shadowed `for`: for-each with long single-form body"
 ------------------------------
 
 
-test: "shadowed `for`: for-each with multiple body forms"
+no-change-test: "shadowed `for`: for-each with multiple body forms"
 ------------------------------
 (define (for lst f)
   (for-each f lst))
@@ -164,7 +164,7 @@ test: "shadowed `for`: for-each with multiple body forms"
 ------------------------------
 
 
-test: "shadowed `for/vector`: list->vector with for/list"
+no-change-test: "shadowed `for/vector`: list->vector with for/list"
 ------------------------------
 (define (for/vector f v)
   (list->vector (map f (vector->list v))))
@@ -175,7 +175,7 @@ test: "shadowed `for/vector`: list->vector with for/list"
 ------------------------------
 
 
-test: "shadowed `for*`: nested for forms"
+no-change-test: "shadowed `for*`: nested for forms"
 ------------------------------
 (define (for* lsts f)
   (for-each (λ (args) (apply f args)) (apply cartesian-product lsts)))
@@ -188,7 +188,7 @@ test: "shadowed `for*`: nested for forms"
 ------------------------------
 
 
-test: "shadowed `for*`: for-each and append-map"
+no-change-test: "shadowed `for*`: for-each and append-map"
 ------------------------------------------------------------
 (define (for* lsts f)
   (for-each (λ (args) (apply f args)) (apply cartesian-product lsts)))
@@ -201,7 +201,7 @@ test: "shadowed `for*`: for-each and append-map"
 ------------------------------------------------------------
 
 
-test: "shadowed `struct`: define-struct without options"
+no-change-test: "shadowed `struct`: define-struct without options"
 ----------------------------------------
 (define (struct name n)
   (define-values (struct:name _1 _2 _3 _4) (make-struct-type name #f n 0))
@@ -210,7 +210,7 @@ test: "shadowed `struct`: define-struct without options"
 ----------------------------------------
 
 
-test: "shadowed `define`: let forms inside for loop bodies"
+no-change-test: "shadowed `define`: let forms inside for loop bodies"
 ------------------------------
 (define-values (definitions) (make-hasheq))
 (define-values (define)
@@ -221,7 +221,7 @@ test: "shadowed `define`: let forms inside for loop bodies"
 ------------------------------
 
 
-test: "shadowed `call-with-values`: let-values expressions with an immediate call"
+no-change-test: "shadowed `call-with-values`: let-values expressions with an immediate call"
 ------------------------------
 (define (call-with-values generator receiver)
   ((compose receiver generator)))
@@ -229,14 +229,14 @@ test: "shadowed `call-with-values`: let-values expressions with an immediate cal
 ------------------------------
 
 
-test: "shadowed `last`: first reverse of list"
+no-change-test: "shadowed `last`: first reverse of list"
 ------------------------------
 (define (last l) (apply max l))
 (first (reverse (list 1 2 3)))
 ------------------------------
 
 
-test: "shadowed `append-map`: (append* (map ...))"
+no-change-test: "shadowed `append-map`: (append* (map ...))"
 ------------------------------
 (define ((append-map f) lst) (append* (map f lst)))
 (define (f x) (list x x x))
@@ -244,7 +244,7 @@ test: "shadowed `append-map`: (append* (map ...))"
 ------------------------------
 
 
-test: "shadowed `match-define`: single-clause match expressions"
+no-change-test: "shadowed `match-define`: single-clause match expressions"
 ------------------------------
 (define-syntax-rule (match-define head clause ...)
   (define/match head clause ...))
@@ -256,35 +256,35 @@ test: "shadowed `match-define`: single-clause match expressions"
 ------------------------------
 
 
-test: "shadowed `add1`: lambda equivalent to add1"
+no-change-test: "shadowed `add1`: lambda equivalent to add1"
 ------------------------------
 (define (add1 v) (cons 1 v))
 (map (λ (x) (+ x 1)) (list 1 2 3))
 ------------------------------
 
 
-test: "shadowed `sub1`: lambda equivalent to sub1"
+no-change-test: "shadowed `sub1`: lambda equivalent to sub1"
 ------------------------------
 (define (sub1 v) (rest v))
 (map (λ (x) (- x 1)) (list 1 2 3))
 ------------------------------
 
 
-test: "shadowed `positive?`: lambda equivalent to positive?"
+no-change-test: "shadowed `positive?`: lambda equivalent to positive?"
 ------------------------------
 (define (positive? v) (and (cons? v) (= 1 (first v))))
 (filter (λ (x) (< 0 x)) (list -2 -1 0 1 2))
 ------------------------------
 
 
-test: "shadowed `negative?`: lambda equivalent to negative?"
+no-change-test: "shadowed `negative?`: lambda equivalent to negative?"
 ------------------------------
 (define (negative? v) (and (cons? v) (= -1 (first v))))
 (filter (λ (x) (< x 0)) (list -2 -1 0 1 2))
 ------------------------------
 
 
-test: "shadowed `define-syntax-parse-rule`: define-simple-macro"
+no-change-test: "shadowed `define-syntax-parse-rule`: define-simple-macro"
 ------------------------------
 (define-syntax-rule (define-syntax-parse-rule new old)
   (define-simple-macro (new . args) (old . args)))
@@ -294,7 +294,7 @@ test: "shadowed `define-syntax-parse-rule`: define-simple-macro"
 ------------------------------
 
 
-test: "shadowed `define-syntax-rule`: single-clause syntax-rules macro"
+no-change-test: "shadowed `define-syntax-rule`: single-clause syntax-rules macro"
 ------------------------------
 (define-syntax define-syntax-rule
   (syntax-rules ()
@@ -310,7 +310,7 @@ test: "shadowed `define-syntax-rule`: single-clause syntax-rules macro"
 ------------------------------
 
 
-test: "shadowed `define-syntax-rule` using `define-syntax-parse-rule` after"
+no-change-test: "shadowed `define-syntax-rule` using `define-syntax-parse-rule` after"
 ------------------------------
 (define-syntax my-or
   (syntax-rules ()

--- a/default-recommendations/string-shortcuts-test.rkt
+++ b/default-recommendations/string-shortcuts-test.rkt
@@ -84,7 +84,8 @@ test: "format with only one argument can be removed"
 - "hello"
 
 
-test: "format with only one argument can't be removed when formatting directives are present"
+no-change-test:
+"format with only one argument can't be removed when formatting directives are present"
 - (format "hello ~a")
 
 

--- a/default-recommendations/syntax-parse-shortcuts-test.rkt
+++ b/default-recommendations/syntax-parse-shortcuts-test.rkt
@@ -33,7 +33,8 @@ test: "define-simple-macro with body comments refactorable to define-syntax-pars
 ------------------------------
 
 
-test: "define-syntax-parse-rule not refactorable (https://github.com/jackfirth/resyntax/issues/106)"
+no-change-test:
+"define-syntax-parse-rule not refactorable (https://github.com/jackfirth/resyntax/issues/106)"
 ------------------------------
 (define-syntax-parse-rule (my-or a:expr b:expr)
   ;; The let form is needed to avoid evaluating a twice.

--- a/default-recommendations/syntax-shortcuts-test.rkt
+++ b/default-recommendations/syntax-shortcuts-test.rkt
@@ -26,7 +26,7 @@ test: "syntax-e on a single format-id argument is removable"
 - (format-id #'foo "~a.~a.~a" #'bar #'baz #'blah)
 
 
-test: "format-id call without any syntax-e unwrapped arguments not refactorable"
+no-change-test: "format-id call without any syntax-e unwrapped arguments not refactorable"
 - (format-id #'foo "~a.~a.~a" #'bar #'baz #'blah)
 
 

--- a/default-recommendations/unused-binding-suggestions-test.rkt
+++ b/default-recommendations/unused-binding-suggestions-test.rkt
@@ -20,7 +20,7 @@ test: "should remove unused function definitions from internal definition contex
 ------------------------------
 
 
-test: "should not remove used function definitions from internal definition contexts"
+no-change-test: "should not remove used function definitions from internal definition contexts"
 ------------------------------
 (define (foo)
   (define (bar)

--- a/main.scrbl
+++ b/main.scrbl
@@ -541,12 +541,12 @@ what @hash-lang[] each code block in that file is written in.
 
 @subsection{Test Statements}
 
-The @racketmodname[resyntax/test] language supports three types of @tech{test statements}:
+The @racketmodname[resyntax/test] language supports four types of @tech{test statements}:
 
 @itemlist[
  @item{@racket[require:] statements for loading @tech{refactoring suites}}
  @item{@racket[header:] statements for defining common code used in all tests}
- @item{@racket[test:] statements for defining individual test cases}]
+ @item{@racket[test:] and @racket[no-change-test:] statements for defining individual test cases}]
 
 
 @defform[#:kind "test statement" (require: module-path suite-name)]{
@@ -576,11 +576,11 @@ The @racketmodname[resyntax/test] language supports three types of @tech{test st
   --------------------
 }}
 
-@defform[#:kind "test statement" (test: description-string test-body ...)]{
- Defines a test case with the given @racket[description-string]. The @racket[test-body] consists of
- one or more @tech{code blocks}. The number of code blocks determines what the test checks. If two
- code blocks are provided, the test case checks that Resyntax refactors the first block into the
- second:
+
+@defform[#:kind "test statement"
+         (test: description-string input-code-block ...+ expected-code-block)]{
+ Defines a test case named with the given @racket[description-string]. The test case checks that
+ Resyntax refactors each @racket[input-code-block] block into the final @racket[expected-code-block]:
 
  @verbatim{
   #lang resyntax/test
@@ -593,28 +593,22 @@ The @racketmodname[resyntax/test] language supports three types of @tech{test st
   #lang racket
   (new-function 1 2 3)
   --------------------
- }
-
- If more than two code blocks are provided, the last code block is the desired code and the test case
- checks that Resyntax refactors @emph{each} of the preceding code blocks into the desired code:
-
- @verbatim{
-  #lang resyntax/test
 
   test: "should remove old-condition from and expressions"
   - (and old-condition x)
   - (and x old-condition)
   - (and old-condition x old-condition)
   - x
- }
+ }}
 
- When only a single code block is provided, the resulting test checks that Resyntax does @emph{not}
- make any changes to the code block:
+@defform[#:kind "test statement" (no-change-test: description-string input-code-block)]{
+ Defines a test case named with the given @racket[description-string]. The test checks that Resyntax
+ does @emph{not} make any changes to the @racket[input-code-block]:
 
  @verbatim{
   #lang resyntax/test
 
-  test: "should not rewrite old function to new function in higher-order uses"
+  no-change-test: "should not rewrite old function to new function in higher-order uses"
   --------------------
   #lang racket
   (map old-function (list 1 2 3))

--- a/test.rkt
+++ b/test.rkt
@@ -12,6 +12,7 @@
          require:
          statement
          test:
+         no-change-test:
          analysis-test:)
 
 
@@ -106,10 +107,6 @@
   (define-splicing-syntax-class code-block-test-args
     #:attributes ([check 1])
 
-    (pattern code:literal-code-block
-      #:with (check ...)
-      (list (syntax/loc #'code (check-suite-does-not-refactor code))))
-
     (pattern (~seq input-code:literal-code-block expected-code:literal-code-block)
       #:with (check ...)
       (list (syntax/loc #'input-code (check-suite-refactors input-code expected-code))))
@@ -132,6 +129,17 @@
         #`(test-case name
             (parameterize ([params.id params.value] ...)
               args.check ...))]))))
+
+
+(define-syntax no-change-test:
+  (statement-transformer
+   (λ (stx)
+     (syntax-parse stx
+       #:track-literals
+       [(_ _ name:str params:test-parameters code:literal-code-block)
+        #`(test-case name
+            (parameterize ([params.id params.value] ...)
+              #,(syntax/loc #'code (check-suite-does-not-refactor code))))]))))
 
 
 (begin-for-syntax

--- a/test/explicit-require-no-auto-test.rkt
+++ b/test/explicit-require-no-auto-test.rkt
@@ -2,5 +2,5 @@
 
 require: resyntax/default-recommendations list-shortcuts
 
-test: "explicit require should not get automatic default-recommendations"
+no-change-test: "explicit require should not get automatic default-recommendations"
 - (and (and 1 2) 3)


### PR DESCRIPTION
This makes it much more obvious which tests check that Resyntax *does* refactor something and which tests check that Resyntax *doesn't* refactor something.