### PR TITLE
Make single-line code blocks parse distinctly

### DIFF
--- a/test/private/grammar.rkt
+++ b/test/private/grammar.rkt
@@ -3,12 +3,22 @@
 
 begin: statement*
 statement: COLON-IDENTIFIER (option | expression | code-block-sequence)+
-@expression: standalone-code-block | range-set | IDENTIFIER | LITERAL-STRING | LITERAL-INTEGER
 option: AT-SIGN-IDENTIFIER expression
 
 
+@expression: code-line
+           | standalone-code-block
+           | range-set
+           | IDENTIFIER
+           | LITERAL-STRING
+           | LITERAL-INTEGER
+
+
+code-line: /SINGLE-DASH CODE-LINE
+standalone-code-block: /DASH-LINE CODE-LINE* /DASH-LINE
+
+
 @code-block-sequence: starting-code-block middle-code-block* ending-code-block+
-standalone-code-block: (/SINGLE-DASH CODE-LINE) | (/DASH-LINE CODE-LINE* /DASH-LINE)
 starting-code-block: /DASH-LINE CODE-LINE* /EQUALS-LINE
 middle-code-block: CODE-LINE* /EQUALS-LINE
 ending-code-block: CODE-LINE* /DASH-LINE


### PR DESCRIPTION
This makes it possible to tell the difference between `- foo` and `---\nfoo\n---` in `#lang resyntax/test` just by looking at the structure of the syntax objects produced by the reader.