### PR TITLE
Add prefixed code blocks to `#lang resyntax/test`

### DIFF
--- a/test.rkt
+++ b/test.rkt
@@ -327,7 +327,14 @@
 
   (define-syntax-class multi-line-code-block-tag
     (pattern
-      (~or #:standalone-code-block #:starting-code-block #:middle-code-block #:ending-code-block)))
+      (~or #:standalone-code-block
+           #:prefixed-standalone-code-block
+           #:first-code-block
+           #:middle-code-block
+           #:last-code-block
+           #:prefixed-first-code-block
+           #:prefixed-middle-code-block
+           #:prefixed-last-code-block)))
 
 
   (define (join-multiline-code-blocks stx)

--- a/test/private/grammar.rkt
+++ b/test/private/grammar.rkt
@@ -8,6 +8,7 @@ option: /AT-SIGN IDENTIFIER expression
 
 @expression: code-line
            | standalone-code-block
+           | prefixed-standalone-code-block
            | range-set
            | IDENTIFIER
            | LITERAL-STRING
@@ -16,12 +17,21 @@ option: /AT-SIGN IDENTIFIER expression
 
 code-line: /SINGLE-DASH CODE-LINE
 standalone-code-block: /DASH-LINE CODE-LINE* /DASH-LINE
+prefixed-standalone-code-block: /PIPE-DASH-LINE (/PIPE-SPACE CODE-LINE)* /PIPE-DASH-LINE
 
 
-@code-block-sequence: starting-code-block middle-code-block* ending-code-block+
-starting-code-block: /DASH-LINE CODE-LINE* /EQUALS-LINE
+@code-block-sequence: first-code-block middle-code-block* last-code-block+
+                    | prefixed-first-code-block prefixed-middle-code-block* prefixed-last-code-block+
+
+
+first-code-block: /DASH-LINE CODE-LINE* /EQUALS-LINE
 middle-code-block: CODE-LINE* /EQUALS-LINE
-ending-code-block: CODE-LINE* /DASH-LINE
+last-code-block: CODE-LINE* /DASH-LINE
+
+
+prefixed-first-code-block: /PIPE-DASH-LINE (/PIPE-SPACE CODE-LINE)* /PIPE-EQUALS-LINE
+prefixed-middle-code-block: (/PIPE-SPACE CODE-LINE)* /PIPE-EQUALS-LINE
+prefixed-last-code-block: (/PIPE-SPACE CODE-LINE)* /PIPE-DASH-LINE
 
 
 range-set: line-range (/COMMA line-range)*

--- a/test/testing-lang-test.rkt
+++ b/test/testing-lang-test.rkt
@@ -1,0 +1,27 @@
+#lang resyntax/test
+
+
+header: - #lang resyntax/test
+
+
+test: "unnecessary multi-line code blocks in tests refactorable to single-line code blocks"
+|-------------------
+| test: "foo"
+| ------------------
+| (and a (and b c))
+| ==================
+| (and a b c)
+| ------------------
+|===================
+| test: "foo"
+| ------------------
+| (and a (and b c))
+| ------------------
+| ------------------
+| (and a b c)
+| ------------------
+|===================
+| test: "foo"
+| - (and a (and b c))
+| - (and a b c)
+|-------------------


### PR DESCRIPTION
Closes #587.