### PR TITLE
Be more fault-tolerant during analysis

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -198,15 +198,13 @@
 
   (define (skip e)
     (log-resyntax-error
-     "skipping ~a\n encountered an error during macro expansion\n  error:\n~a"
+     "skipping ~a\n encountered an error during initial analysis\n  error:\n~a"
      (or (source-path source) "string source")
      (string-indent (exn-message e) #:amount 3))
     empty-list)
 
   (define results
-    (with-handlers ([exn:fail:syntax? skip]
-                    [exn:fail:filesystem:missing-module? skip]
-                    [exn:fail:contract:variable? skip])
+    (with-handlers ([exn:fail? skip])
       (define analysis (source-analyze source #:lines lines))
       (refactor-visited-forms
        #:analysis analysis #:suite effective-suite #:comments comments #:lines lines)))


### PR DESCRIPTION
This should fix problems where bugs in the initial source analysis pass cause an entire Autofixer run to fail, as seen [here](https://github.com/racket/drracket/actions/runs/17703709869/job/50312526478).