### PR TITLE
Fix a comment reader bug

### DIFF
--- a/private/source.rkt
+++ b/private/source.rkt
@@ -201,6 +201,7 @@
 (define (source-tokens src)
   (with-input-from-source src
     (λ ()
+      (port-count-lines! (current-input-port))
       (define tokens (make-vector-builder))
       (let loop ([offset 0] [mode #false])
         (define-values (text raw-attributes delimiter-kind start end _ new-mode)


### PR DESCRIPTION
Some languages have lexers that only work if the input port has line counting enabled. Found via running Resyntax on [this file](https://github.com/racket/typed-racket/blob/master/typed-racket-test/succeed/2d-typed.rkt) which uses `#lang 2d typed/racket/base`.