### PR TITLE
Remove redundant subtype-specific source accessors

### DIFF
--- a/cli.rkt
+++ b/cli.rkt
@@ -301,7 +301,7 @@ For help on these, use 'analyze --help' or 'fix --help'."
       [(== plain-text)
        (for ([result (in-list results)])
          (define path
-           (file-source-path
+           (source-path
             (syntax-replacement-source (refactoring-result-syntax-replacement result))))
          (define line (refactoring-result-original-line result))
          (define column (refactoring-result-original-column result))

--- a/grimoire.scrbl
+++ b/grimoire.scrbl
@@ -67,23 +67,12 @@ stack of dependent changes to commit in series without actually mutating the fil
  normalized with @racket[simple-form-path] upon construction.}
 
 
-@defproc[(file-source-path [code file-source?]) path?]{
- Returns the filesystem path that @racket[code] refers to.}
-
-
 @defproc[(string-source? [v any/c]) boolean?]{
  A predicate that recognizes source strings.}
 
 
 @defproc[(string-source [contents string?]) string-source?]{
  Constructs a source string containing @racket[contents] directly.}
-
-
-@defproc[(string-source-contents [code string-source?]) immutable-string?]{
- Returns the source code text contained within @racket[code]. Note that this is a distinct operation
- from @racket[source->string] --- the latter returns the current source code text of @emph{any} source
- code, which may involve reading files from disk. This operation, in contrast, cannot perform I/O
- because it only operates on an unmodified @racket[string-source?].}
 
 
 @defproc[(modified-source? [v any/c]) boolean?]{
@@ -97,15 +86,6 @@ stack of dependent changes to commit in series without actually mutating the fil
  @racket[new-contents]. This represents a whole-file replacement --- the @emph{complete} contents of
  @racket[original] are @emph{entirely} swapped out with @racket[new-contents]. Modified sources cannot
  represent partial edits on their own.}
-
-
-@defproc[(modified-source-contents [code modified-source?]) immutable-string?]{
- Returns the new, updated contents of @racket[code], ignoring whatever contents the original source
- of @racket[code] had.}
-
-
-@defproc[(modified-source-original [code modified-source?]) unmodified-source?]{
- Returns the original, unmodified source that @racket[code] was constructed from.}
 
 
 @defproc[(source-name [code source?]) (or/c path? symbol?)]{

--- a/grimoire/source.rkt
+++ b/grimoire/source.rkt
@@ -21,14 +21,10 @@
   [source-comment-locations (-> source? immutable-range-set?)]
   [file-source? (-> any/c boolean?)]
   [file-source (-> path-string? file-source?)]
-  [file-source-path (-> file-source? path?)]
   [string-source? (-> any/c boolean?)]
   [string-source (-> string? string-source?)]
-  [string-source-contents (-> string-source? immutable-string?)]
   [modified-source? (-> any/c boolean?)]
   [modified-source (-> unmodified-source? string? modified-source?)]
-  [modified-source-contents (-> modified-source? immutable-string?)]
-  [modified-source-original (-> modified-source? unmodified-source?)]
   [with-input-from-source (-> source? (-> any) any)]))
 
 

--- a/main.rkt
+++ b/main.rkt
@@ -90,7 +90,7 @@
   (transduce (resyntax-analysis-all-results analysis)
              (append-mapping in-hash-values)
              (mapping refactoring-result-set-updated-source)
-             (indexing modified-source-original)
+             (indexing source-original)
              (grouping nonempty-into-last)
              (mapping entry-value)
              #:into into-list))
@@ -130,7 +130,7 @@
   (for ([source (in-list sources)]
         #:when (source-path source))
     (log-resyntax-info "fixing ~a" (source-path source))
-    (display-to-file (modified-source-contents source) (source-path source)
+    (display-to-file (source->string source) (source-path source)
                      #:mode 'text #:exists 'replace)))
 
 
@@ -465,7 +465,7 @@
     (transduce results
                (bisecting
                 (λ (result)
-                  (file-source-path
+                  (source-path
                    (syntax-replacement-source (refactoring-result-syntax-replacement result))))
                 refactoring-result-string-replacement)
                (grouping union-into-string-replacement)

--- a/private/github.rkt
+++ b/private/github.rkt
@@ -94,7 +94,7 @@
 
 (define (refactoring-result->github-review-comment result)
   (define path
-    (file-source-path (syntax-replacement-source (refactoring-result-syntax-replacement result))))
+    (source-path (syntax-replacement-source (refactoring-result-syntax-replacement result))))
   (define replacement (refactoring-result-line-replacement result))
   (define body
     (format #<<EOS

--- a/private/universal-tagged-syntax.rkt
+++ b/private/universal-tagged-syntax.rkt
@@ -178,4 +178,4 @@
     (define stx (source-read-syntax src))
     (define written-form (universal-tagged-syntax->string stx))
 
-    (check-equal? written-form (string-source-contents src))))
+    (check-equal? written-form (source->string src))))

--- a/test/private/rackunit.rkt
+++ b/test/private/rackunit.rkt
@@ -197,7 +197,7 @@
                      ['exception e])
                   (fail-check "an error occurred while processing refactoring results")))])
           (call-with-logs-captured
-           (λ () (modified-source-contents (refactoring-result-set-updated-source result-set))))))
+           (λ () (source->string (refactoring-result-set-updated-source result-set))))))
       (with-check-info (['logs (build-logs-info)]
                         ['actual (string-block-info refactored-program)]
                         ['expected (string-block-info (code-block-raw-string expected-program))])
@@ -235,7 +235,7 @@
                          #:suite suite
                          #:timeout-ms (current-analyzer-timeout-millis)))))
   (define refactored-program
-    (modified-source-contents (refactoring-result-set-updated-source result-set)))
+    (source->string (refactoring-result-set-updated-source result-set)))
   (with-check-info* (make-matched-rules-check-info result-set)
     (λ ()
       (with-check-info (['logs (build-logs-info)]
@@ -283,16 +283,16 @@
 
   (unless target-path
     (with-check-info (['logs (build-logs-info)]
-                      ['program (string-block-info (string-source-contents program-src))]
-                      ['target (string-block-info (string-source-contents target-src))])
+                      ['program (string-block-info (source->string program-src))]
+                      ['target (string-block-info (source->string target-src))])
       (fail-check "could not locate target subform within the given program")))
 
   (define (fail-property-lookup)
     (define target-properties
       (syntax-property-bundle-get-immediate-properties actual-props target-path))
     (with-check-info (['logs (build-logs-info)]
-                      ['program (string-block-info (string-source-contents program-src))]
-                      ['target (string-block-info (string-source-contents target-src))]
+                      ['program (string-block-info (source->string program-src))]
+                      ['target (string-block-info (source->string target-src))]
                       ['target-path target-path]
                       ['target-properties target-properties]
                       ['property-key property-key])
@@ -303,8 +303,8 @@
 
   (unless (equal? actual-value expected-value)
     (with-check-info (['logs (build-logs-info)]
-                      ['program (string-block-info (string-source-contents program-src))]
-                      ['target (string-block-info (string-source-contents target-src))]
+                      ['program (string-block-info (source->string program-src))]
+                      ['target (string-block-info (source->string target-src))]
                       ['target-path target-path]
                       ['property-key property-key]
                       ['actual actual-value]
@@ -314,7 +314,7 @@
 
 (define (source-find-path-of src target-src #:contexts [context-srcs '()])
   (define stx (syntax-label-paths (source-read-syntax src) 'source-path))
-  (define target-as-string (string-source-contents target-src))
+  (define target-as-string (source->string target-src))
 
   (define target-stx
     (let loop ([stx stx] [context-srcs context-srcs])
@@ -323,7 +323,7 @@
          (syntax-find-first stx subform
             #:when (equal? (source-text-of src (attribute subform)) target-as-string))]
         [(cons next-context remaining-contexts)
-         (define next-as-string (string-source-contents next-context))
+         (define next-as-string (source->string next-context))
          (define substx
            (syntax-find-first stx subform
              #:when (equal? (source-text-of src (attribute subform)) next-as-string)))


### PR DESCRIPTION
## What changed

Removes four accessors from the `resyntax/grimoire/source` public API that were specific to one of the three source subtypes and redundant with the generic operations that work on any source:

- `file-source-path` → use `source-path`
- `string-source-contents` → use `source->string`
- `modified-source-contents` → use `source->string`
- `modified-source-original` → use `source-original`

All call sites across `main.rkt`, `cli.rkt`, `private/github.rkt`, `private/universal-tagged-syntax.rkt`, and `test/private/rackunit.rkt` now use the generic equivalents, and the corresponding `@defproc` entries are removed from the grimoire docs.

## Why

These APIs were recently documented in the grimoire, which made their redundancy apparent. A smaller API surface with one way to do each operation is easier to document and easier for the grimoire's audience to learn from.

## Notes for reviewers

- The struct-generated accessors still exist privately; `modified-source-original` is still used internally to implement `source-original`.
- `source-path` returns `(or/c path? #false)` rather than the guaranteed `path?` of `file-source-path`, but every replaced call site operates on file-backed sources in practice, so behavior is unchanged.
- `raco setup --pkgs resyntax` rebuilds cleanly and the tests for the affected modules pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)