### PR TITLE
Only rewrite multi-body when/unless expressions to loop keywords

### DIFF
--- a/default-recommendations/loops/for-loop-shortcuts-test.rkt
+++ b/default-recommendations/loops/for-loop-shortcuts-test.rkt
@@ -341,51 +341,91 @@ test: "nested for/and forms can be flattened to a for*/and form"
 ------------------------------
 
 
-test: "(when ...) in a for loop refactored to #:when clause"
+test: "multi-body (when ...) in a for loop refactored to #:when clause"
 ------------------------------------------------------------
 (for ([x (in-list (list 1 2 'a 3 'b 4))])
   (when (number? x)
+    (displayln x)
     (displayln x)))
 ============================================================
 (for ([x (in-list (list 1 2 'a 3 'b 4))]
       #:when (number? x))
+  (displayln x)
   (displayln x))
 ------------------------------------------------------------
 
 
-test: "(when ...) in a for* loop refactored to #:when clause"
+test: "multi-body (when ...) in a for* loop refactored to #:when clause"
 ------------------------------------------------------------
 (for* ([x (in-list (list 1 2 'a 3 'b 4))])
   (when (number? x)
+    (displayln x)
     (displayln x)))
 ============================================================
 (for* ([x (in-list (list 1 2 'a 3 'b 4))]
        #:when (number? x))
+  (displayln x)
   (displayln x))
 ------------------------------------------------------------
 
 
-test: "(unless ...) in a for loop refactored to #:when clause"
+test: "multi-body (unless ...) in a for loop refactored to #:unless clause"
 ------------------------------------------------------------
 (for ([x (in-list (list 1 2 'a 3 'b 4))])
   (unless (number? x)
+    (displayln x)
     (displayln x)))
 ============================================================
 (for ([x (in-list (list 1 2 'a 3 'b 4))]
       #:unless (number? x))
+  (displayln x)
   (displayln x))
 ------------------------------------------------------------
 
 
-test: "(unless ...) in a for* loop refactored to #:when clause"
+test: "multi-body (unless ...) in a for* loop refactored to #:unless clause"
 ------------------------------------------------------------
 (for* ([x (in-list (list 1 2 'a 3 'b 4))])
   (unless (number? x)
+    (displayln x)
     (displayln x)))
 ============================================================
 (for* ([x (in-list (list 1 2 'a 3 'b 4))]
        #:unless (number? x))
+  (displayln x)
   (displayln x))
+------------------------------------------------------------
+
+
+no-change-test: "single-body (when ...) in a for loop not refactorable to #:when clause"
+------------------------------------------------------------
+(for ([x (in-list (list 1 2 'a 3 'b 4))])
+  (when (number? x)
+    (displayln x)))
+------------------------------------------------------------
+
+
+no-change-test: "single-body (when ...) in a for* loop not refactorable to #:when clause"
+------------------------------------------------------------
+(for* ([x (in-list (list 1 2 'a 3 'b 4))])
+  (when (number? x)
+    (displayln x)))
+------------------------------------------------------------
+
+
+no-change-test: "single-body (unless ...) in a for loop not refactorable to #:unless clause"
+------------------------------------------------------------
+(for ([x (in-list (list 1 2 'a 3 'b 4))])
+  (unless (number? x)
+    (displayln x)))
+------------------------------------------------------------
+
+
+no-change-test: "single-body (unless ...) in a for* loop not refactorable to #:unless clause"
+------------------------------------------------------------
+(for* ([x (in-list (list 1 2 'a 3 'b 4))])
+  (unless (number? x)
+    (displayln x)))
 ------------------------------------------------------------
 
 

--- a/default-recommendations/loops/for-loop-shortcuts.rkt
+++ b/default-recommendations/loops/for-loop-shortcuts.rkt
@@ -257,18 +257,22 @@ return just that result."
    (~@ . (~splicing-replacement (last-condition.refactored ...) #:original original-body))))
 
 
+;; The following two rules require multiple body forms because rewriting a single-body when/unless
+;; expression doesn't meaningfully reduce indentation or improve the code.
+
+
 (define-refactoring-rule when-expression-in-for-loop-to-when-keyword
   #:description "Use the `#:when` keyword instead of `when` to reduce loop body indentation."
   #:literals (when for for*)
-  ((~or for-id:for for-id:for*) (clause ...) (when condition body ...))
-  (for-id (clause ... #:when condition) body ...))
+  ((~or for-id:for for-id:for*) (clause ...) (when condition first-body remaining-body ...+))
+  (for-id (clause ... #:when condition) first-body remaining-body ...))
 
 
 (define-refactoring-rule unless-expression-in-for-loop-to-unless-keyword
   #:description "Use the `#:unless` keyword instead of `unless` to reduce loop body indentation."
   #:literals (unless for for*)
-  ((~or for-id:for for-id:for*) (clause ...) (unless condition body ...))
-  (for-id (clause ... #:unless condition) body ...))
+  ((~or for-id:for for-id:for*) (clause ...) (unless condition first-body remaining-body ...+))
+  (for-id (clause ... #:unless condition) first-body remaining-body ...))
 
 
 (define-refactoring-rule in-hash-to-in-hash-keys


### PR DESCRIPTION
Fixes #765.