### PR TITLE
Add rule flattening apply/append/map syntax templates

### DIFF
--- a/default-recommendations/syntax-shortcuts-test.rkt
+++ b/default-recommendations/syntax-shortcuts-test.rkt
@@ -53,3 +53,17 @@ test: "making a symbol with format from a keyword can be simplified to format-sy
 test: "making a symbol with format from a keyword syntax object can be simplified to format-symbol"
 - (string->symbol (format "make-~a" (keyword->string (syntax-e #'#:foo))))
 - (format-symbol "make-~a" #'#:foo)
+
+
+test: "flattening a nested ellipsis template can be simplified to a flat template"
+------------------------------------------------------------------------------------------------------
+(define (f stx)
+  (with-syntax ([((a ...) ...) stx])
+    (apply append
+           (map syntax->list (syntax->list #'((a ...) ...))))))
+------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------
+(define (f stx)
+  (with-syntax ([((a ...) ...) stx])
+    (syntax->list #'(a ... ...))))
+------------------------------------------------------------------------------------------------------

--- a/default-recommendations/syntax-shortcuts.rkt
+++ b/default-recommendations/syntax-shortcuts.rkt
@@ -103,6 +103,20 @@
   (format-symbol template (~replacement arg.simplified #:original arg) ...))
 
 
+(define-refactoring-rule flatten-apply-append-syntax-template
+  #:description
+  "Flattening a nested ellipsis syntax template with `apply`, `append`, and `map` can be expressed\
+ more directly with a single flattened ellipsis template."
+  #:literals (apply append map syntax->list syntax)
+
+  (apply append
+         (map syntax->list
+              (syntax->list (syntax ((elem (~datum ...)) (~datum ...))))))
+
+  (syntax->list #'(elem (... ...) (... ...))))
+
+
 (define-refactoring-suite syntax-shortcuts
-  #:rules (format-string-to-format-symbol
+  #:rules (flatten-apply-append-syntax-template
+           format-string-to-format-symbol
            syntax-e-in-format-id-unnecessary))

--- a/private/syntax-replacement.rkt
+++ b/private/syntax-replacement.rkt
@@ -141,12 +141,14 @@
       (define end (+ start (syntax-span stx)))
       (list (copied-string start end)))
     (syntax-parse stx
-      #:literals (quote)
+      #:literals (quote syntax)
 
       [(~or v:id v:boolean v:char v:keyword v:number v:regexp v:byte-regexp v:string v:bytes)
        (list (inserted-string (string->immutable-string (~s (syntax-e #'v)))))]
-      
+
       [(quote datum) (cons (inserted-string "'") (pieces #'datum #:focused? focused?))]
+
+      [(syntax datum) (cons (inserted-string "#'") (pieces #'datum #:focused? focused?))]
       
       [(subform ...)
        (define shape (syntax-property stx 'paren-shape))


### PR DESCRIPTION
Fixes #769.

Also teaches the s-expression renderer to print constructed `syntax` forms as `#'`, mirroring its existing `quote` → `'` handling, so the rewritten template reads as `#'(a ... ...)` rather than `(syntax (a ... ...))`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)