### PR TITLE
Allow comments in refactoring test files

### DIFF
--- a/test/private/tokenizer.rkt
+++ b/test/private/tokenizer.rkt
@@ -27,7 +27,7 @@
 (define-lex-abbrev rest-of-line
   (concatenation (complement (concatenation any-string #\newline any-string)) #\newline))
 
-(define-lex-abbrev comment-line (concatenation ";" rest-of-line))
+(define-lex-abbrev comment-line (concatenation "//" rest-of-line))
 
 (define-lex-abbrev dash-line (concatenation (repetition 3 +inf.0 #\-) #\newline))
 (define-lex-abbrev equals-line (concatenation (repetition 3 +inf.0 #\=) #\newline))
@@ -170,15 +170,15 @@
       (check-equal? (tokenize-until-eof tokenizer) expected-tokens))
 
     (test-case "comments between statements"
-      (define input (open-input-string "header:\n; a comment\n- #lang racket\n"))
+      (define input (open-input-string "header:\n// a comment\n- #lang racket\n"))
       (port-count-lines! input)
       (define tokenizer (make-refactoring-test-tokenizer input))
       (define expected-tokens
         (list
          (position-token (token-IDENTIFIER 'header) (position 1 1 0) (position 7 1 6))
          (position-token (token-COLON) (position 7 1 6) (position 8 1 7))
-         (position-token (token-SINGLE-DASH) (position 21 3 0) (position 23 3 2))
-         (position-token (token-CODE-LINE "#lang racket\n") (position 23 3 2) (position 36 4 0))))
+         (position-token (token-SINGLE-DASH) (position 22 3 0) (position 24 3 2))
+         (position-token (token-CODE-LINE "#lang racket\n") (position 24 3 2) (position 37 4 0))))
       (check-equal? (tokenize-until-eof tokenizer) expected-tokens))
 
     (test-case "code blocks"

--- a/test/private/tokenizer.rkt
+++ b/test/private/tokenizer.rkt
@@ -27,6 +27,8 @@
 (define-lex-abbrev rest-of-line
   (concatenation (complement (concatenation any-string #\newline any-string)) #\newline))
 
+(define-lex-abbrev comment-line (concatenation ";" rest-of-line))
+
 (define-lex-abbrev dash-line (concatenation (repetition 3 +inf.0 #\-) #\newline))
 (define-lex-abbrev equals-line (concatenation (repetition 3 +inf.0 #\=) #\newline))
 (define-lex-abbrev pipe-dash-line (concatenation "|" dash-line))
@@ -83,6 +85,7 @@
   (define initial-lexer
     (lexer-src-pos
      [whitespace (return-without-pos (initial-lexer input-port))]
+     [comment-line (return-without-pos (initial-lexer input-port))]
      [":" (token-COLON)]
      ["@" (token-AT-SIGN)]
      [".." (token-DOUBLE-DOT)]
@@ -164,6 +167,18 @@
          (position-token (token-COLON) (position 7 1 6) (position 8 1 7))
          (position-token (token-SINGLE-DASH) (position 9 2 0) (position 11 2 2))
          (position-token (token-CODE-LINE "#lang racket\n") (position 11 2 2) (position 24 3 0))))
+      (check-equal? (tokenize-until-eof tokenizer) expected-tokens))
+
+    (test-case "comments between statements"
+      (define input (open-input-string "header:\n; a comment\n- #lang racket\n"))
+      (port-count-lines! input)
+      (define tokenizer (make-refactoring-test-tokenizer input))
+      (define expected-tokens
+        (list
+         (position-token (token-IDENTIFIER 'header) (position 1 1 0) (position 7 1 6))
+         (position-token (token-COLON) (position 7 1 6) (position 8 1 7))
+         (position-token (token-SINGLE-DASH) (position 21 3 0) (position 23 3 2))
+         (position-token (token-CODE-LINE "#lang racket\n") (position 23 3 2) (position 36 4 0))))
       (check-equal? (tokenize-until-eof tokenizer) expected-tokens))
 
     (test-case "code blocks"

--- a/test/testing-lang-test.rkt
+++ b/test/testing-lang-test.rkt
@@ -4,7 +4,7 @@
 header: - #lang resyntax/test
 
 
-; Comments are allowed between statements (see issue #350).
+// Comments are allowed between statements (see issue #350).
 test: "unnecessary multi-line code blocks in tests refactorable to single-line code blocks"
 |-------------------
 | test: "foo"

--- a/test/testing-lang-test.rkt
+++ b/test/testing-lang-test.rkt
@@ -4,6 +4,7 @@
 header: - #lang resyntax/test
 
 
+; Comments are allowed between statements (see issue #350).
 test: "unnecessary multi-line code blocks in tests refactorable to single-line code blocks"
 |-------------------
 | test: "foo"


### PR DESCRIPTION
Fixes #350. The test language tokenizer now skips `//` comment lines between statements, like it already does for whitespace, so they never reach the grammar. Comments inside code blocks are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)