### PR TITLE
Compare syntax paths directly instead of via a generic lexicographic comparator

### DIFF
--- a/grimoire/syntax-path.rkt
+++ b/grimoire/syntax-path.rkt
@@ -1427,6 +1427,32 @@
        ['< lesser]))))
 
 
+;; This is equivalent to (comparator-map (lexicographic-comparator natural<=>)
+;; syntax-path-elements), but written out by hand because it's extremely hot: expansion analysis
+;; stores every visited syntax object in sorted maps keyed by syntax path, so this comparator runs
+;; a logarithmic number of times per observed expansion event. The generic version pays for
+;; sequence-generate machinery on each treelist and for a contract check on each individual element
+;; comparison, both of which dominate its cost.
 (define syntax-path<=>
-  (comparator-map (lexicographic-comparator natural<=>) syntax-path-elements
-                  #:name 'syntax-path<=>))
+  (make-comparator
+   (λ (left right)
+     (define left-elements (syntax-path-elements left))
+     (define right-elements (syntax-path-elements right))
+     (define left-size (treelist-length left-elements))
+     (define right-size (treelist-length right-elements))
+     (define shared-size (min left-size right-size))
+     (let loop ([i 0])
+       (cond
+         [(>= i shared-size)
+          (cond
+            [(< left-size right-size) lesser]
+            [(> left-size right-size) greater]
+            [else equivalent])]
+         [else
+          (define left-element (treelist-ref left-elements i))
+          (define right-element (treelist-ref right-elements i))
+          (cond
+            [(< left-element right-element) lesser]
+            [(> left-element right-element) greater]
+            [else (loop (add1 i))])])))
+   #:name 'syntax-path<=>))


### PR DESCRIPTION
`syntax-path<=>` was `(comparator-map (lexicographic-comparator natural<=>) syntax-path-elements)`. That generic implementation drives each comparison through `sequence-generate` on both treelists and crosses a contract boundary for every individual element comparison. It's hot enough to dominate expansion analysis, since `source-analyze` keeps every visited syntax object in sorted maps keyed by syntax path.

Writing the comparison out as a direct indexed loop takes analysis of `xrepl-lib/xrepl/xrepl.rkt` (1877 lines) from ~71s to ~44s. `raco test -p resyntax` passes.

This overlaps with #842 — both attack the cost of `syntax-path<=>`, so their speedups don't add. Together they come to ~36s.

Found by profiling, in the same vein as #800.

<sub>Measurement note: figures are the minimum of 3 runs after a warmup. An earlier version of this description said ~78s → ~44s; that baseline was taken on a thermally throttled machine and overstated the ratio. Repeated runs on identical code vary by up to ~6% here, so treat differences smaller than that as unresolved.</sub>