### PR TITLE
Stop traversing whole subtrees to decide if syntax is one line or many

### DIFF
--- a/default-recommendations/private/syntax-lines.rkt
+++ b/default-recommendations/private/syntax-lines.rkt
@@ -10,9 +10,8 @@
   [multiline-syntax? (-> any/c boolean?)]))
 
 
-(require rebellion/streaming/reducer
-         rebellion/streaming/transducer
-         resyntax/private/syntax-traversal)
+(require resyntax/private/syntax-traversal
+         syntax/parse)
 
 
 (module+ test
@@ -25,18 +24,40 @@
 
 
 (define (oneline-syntax? v)
-  (and (syntax? v) (equal? (syntax-line-count v) 1)))
+  (and (syntax? v) (equal? (syntax-line-count v #:limit 2) 1)))
 
 
 (define (multiline-syntax? v)
-  (and (syntax? v) (> (syntax-line-count v) 1)))
+  (and (syntax? v) (> (syntax-line-count v #:limit 2) 1)))
 
 
-(define (syntax-line-count stx)
-  (transduce (syntax-search stx [:atom])
-             (mapping syntax-line)
-             (deduplicating)
-             #:into into-count))
+;; Counts how many distinct source lines the atoms within stx occupy, giving up and returning limit
+;; as soon as that many distinct lines have been seen. Both predicates above only need to
+;; distinguish between zero, one, and multiple lines, and they're checked against enough syntax
+;; objects that traversing entire subtrees after the answer is already determined shows up as a
+;; large chunk of Resyntax's runtime.
+(define (syntax-line-count stx #:limit limit)
+  (let/ec return
+    (define lines-seen '())
+    (let loop ([stx stx])
+      (syntax-parse stx
+        [:atom
+         (define line (syntax-line this-syntax))
+         (unless (member line lines-seen)
+           (set! lines-seen (cons line lines-seen))
+           (when (>= (length lines-seen) limit)
+             (return limit)))]
+        [(part ...)
+         #:cut
+         (for ([part-stx (in-list (attribute part))])
+           (loop part-stx))]
+        [(part ...+ . tail-part)
+         #:cut
+         (for ([part-stx (in-list (attribute part))])
+           (loop part-stx))
+         (loop #'tail-part)]
+        [_ (void)]))
+    (length lines-seen)))
 
 
 (module+ test
@@ -48,7 +69,16 @@
                                      c)))
     (check-false (oneline-syntax? #'(1
                                      2
-                                     3))))
+                                     3)))
+    (check-true (oneline-syntax? #'(a . b)))
+    (check-false (oneline-syntax? #'(a .
+                                       b)))
+    (check-false (oneline-syntax? 'not-syntax))
+
+    ;; Syntax objects containing no atoms at all occupy zero lines, so they're neither one-line nor
+    ;; multiline.
+    (check-false (oneline-syntax? #'()))
+    (check-false (multiline-syntax? #'())))
 
   (test-case (name-string multiline-syntax?)
     (check-false (multiline-syntax? #'a))
@@ -58,4 +88,8 @@
                                       c)))
     (check-true (multiline-syntax? #'(1
                                       2
-                                      3)))))
+                                      3)))
+    (check-false (multiline-syntax? #'(a . b)))
+    (check-true (multiline-syntax? #'(a .
+                                        b)))
+    (check-false (multiline-syntax? 'not-syntax))))


### PR DESCRIPTION
`oneline-syntax?` and `multiline-syntax?` counted every distinct source line among all the atoms in a syntax object, streaming the whole subtree through a transducer pipeline. Neither caller needs an exact count, and both build the full stream even when the second line turns up immediately.

Counting with a direct traversal that stops at two distinct lines takes analysis of `xrepl-lib/xrepl/xrepl.rkt` (1877 lines) from ~71s to ~63s.

The new traversal deliberately mirrors `syntax-search`'s shape, including how it handles improper lists and how it treats non-list, non-atom syntax (vectors, say) as having no lines at all. I ran both implementations over every subform of several large source files plus some hand-built edge cases and got identical answers on all 28,585 syntax objects. `raco test -p resyntax` passes.

Found by profiling, in the same vein as #800.

<sub>Measurement note: figures are the minimum of 3 runs after a warmup. An earlier version of this description said ~78s → ~65s; that baseline was taken on a thermally throttled machine and overstated the ratio. Repeated runs on identical code vary by up to ~6% here, so treat differences smaller than that as unresolved.</sub>